### PR TITLE
chore(technitium-dnsserver): bump chart to 1.9.0 and appVersion to 15.0.1

### DIFF
--- a/charts/technitium-dnsserver/Chart.yaml
+++ b/charts/technitium-dnsserver/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - pihole
   - adguard
 
-version: 1.8.0
-appVersion: "14.3.0"
+version: 1.9.0
+appVersion: "15.0.1"
 
 icon: https://raw.githubusercontent.com/obeone/charts/main/logo/technitium-dnsserver.png
 sources:
@@ -33,4 +33,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion
+      description: Update appVersion to 15.0.1

--- a/charts/technitium-dnsserver/README.md
+++ b/charts/technitium-dnsserver/README.md
@@ -1,6 +1,6 @@
 # Technitium DNS Server Helm Chart
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 14.3](https://img.shields.io/badge/AppVersion-14.3-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.0.1](https://img.shields.io/badge/AppVersion-15.0.1-informational?style=flat-square)
 
 Technitium DNS Server is a powerful and versatile DNS solution that can serve multiple purposes, from enhancing your network security by blocking ads and trackers (similar to Pi-hole or AdGuardHome) to acting as a robust authoritative DNS server for your domains. This Helm chart simplifies its deployment on Kubernetes, allowing you to leverage its advanced features with ease.
 


### PR DESCRIPTION
Update Technitium DNS Server to upstream 15.0.1 (major bump from 14.x).

- appVersion: 14.3.0 -> 15.0.1
- chart version: 1.8.0 -> 1.9.0 (minor, since upstream is a major bump)
- Refresh README badges and changelog annotation