### PR TITLE
chore(technitium-dnsserver): bump chart to 1.10.0 and appVersion to 15.1.0

### DIFF
--- a/charts/technitium-dnsserver/Chart.yaml
+++ b/charts/technitium-dnsserver/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - pihole
   - adguard
 
-version: 1.9.0
-appVersion: "15.0.1"
+version: 1.10.0
+appVersion: "15.1.0"
 
 icon: https://raw.githubusercontent.com/obeone/charts/main/logo/technitium-dnsserver.png
 sources:
@@ -33,4 +33,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to 15.0.1
+      description: Update appVersion to 15.1.0

--- a/charts/technitium-dnsserver/README.md
+++ b/charts/technitium-dnsserver/README.md
@@ -1,6 +1,6 @@
 # Technitium DNS Server Helm Chart
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.0.1](https://img.shields.io/badge/AppVersion-15.0.1-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.1.0](https://img.shields.io/badge/AppVersion-15.1.0-informational?style=flat-square)
 
 Technitium DNS Server is a powerful and versatile DNS solution that can serve multiple purposes, from enhancing your network security by blocking ads and trackers (similar to Pi-hole or AdGuardHome) to acting as a robust authoritative DNS server for your domains. This Helm chart simplifies its deployment on Kubernetes, allowing you to leverage its advanced features with ease.
 


### PR DESCRIPTION
## Summary
- Bump `appVersion` to `15.1.0` (Technitium DNS Server release).
- Bump chart `version` to `1.10.0` so chart-releaser publishes a new release.
- Refresh `artifacthub.io/changes` annotation and README badges.

## Test plan
- [x] `helm dep up charts/technitium-dnsserver` (Chart.lock unchanged — `common` 4.5.2)
- [x] `helm lint charts/technitium-dnsserver` → 0 chart(s) failed