### PR TITLE
docs(readme): refresh top-level README with charts table

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false
+}

--- a/README.md
+++ b/README.md
@@ -1,59 +1,79 @@
-# Helm charts
+# 🚀 obeone/charts
 
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/search?repo=obeone)
+> A curated collection of GPG-signed Helm charts for self-hosted apps.
 
-To use this repository :
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone&style=for-the-badge)](https://artifacthub.io/packages/search?repo=obeone)
+[![Repo](https://img.shields.io/badge/repo-charts.obeone.cloud-2ea44f?style=for-the-badge&logo=helm&logoColor=white)](https://charts.obeone.cloud)
+[![Signed](https://img.shields.io/badge/charts-GPG%20signed-blueviolet?style=for-the-badge&logo=gnuprivacyguard&logoColor=white)](public_key.gpg)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](LICENSE)
+
+---
+
+## ⚡ Quick start
 
 ```console
 helm repo add obeone https://charts.obeone.cloud
 helm repo update
+helm search repo obeone
 ```
 
-All charts are [signed](https://helm.sh/docs/topics/provenance/). You can verify with public key [B9FE852F28888D27F8C9A11CD33E04CD22E335CE](public_key.gpg)
+Install any chart with provenance verification:
 
-## Winbox
+```console
+helm install my-release obeone/<chart> --verify
+```
 
-Mikrotik Winbox in browser [[Sources]](https://github.com/obeone/winbox-docker) [[Chart]](charts/winbox)
+---
 
-## CyberChef
+## 📦 Charts
 
-CyberChef, The Cyber Swiss Army Knife [[Demo]](https://gchq.github.io/cyberchef) [[Sources]](https://github.com/gchq/CyberChef) [[Chart]](charts/cyberchef)
+| | Chart | App | Description |
+| :-: | --- | --- | --- |
+| 🔪 | [**cyberchef**](charts/cyberchef) | `v10.19.4` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
+| 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.14` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
+| 🎨 | [**fooocus**](charts/fooocus) | `latest` | [Fooocus](https://github.com/lllyasviel/Fooocus) — open-source image-generation UI on top of Stable Diffusion. |
+| 🌍 | [**libretranslate**](charts/libretranslate) | `v1.6.5` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
+| 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |
+| 📂 | [**nfs-server**](charts/nfs-server) | `2.2.2` | Lightweight, multi-arch [containerized NFS server](https://github.com/obeone/docker-nfs-server). |
+| 💬 | [**olvid-bot**](charts/olvid-bot) | `1.5.0` | [Olvid bot-daemon](https://gitlab.com/olvid/olvid) — bridge to automate Olvid secure-messaging groups. |
+| 📝 | [**opengist**](charts/opengist) | `1.10.0` | [Opengist](https://github.com/thomiceli/opengist) — self-hosted, Git-backed Pastebin / GitHub Gist alternative. |
+| 🌐 | [**technitium-dnsserver**](charts/technitium-dnsserver) | `15.1.0` | [Technitium DNS Server](https://github.com/TechnitiumSoftware/DnsServer) — recursive / authoritative DNS, PiHole & AdGuard alternative. |
+| 📤 | [**transfer.sh**](charts/transfer.sh) | `v1.6.1` | [transfer.sh](https://github.com/dutchcoders/transfer.sh) — CLI-friendly file-sharing with pluggable storage backends. |
+| 🪟 | [**winbox**](charts/winbox) | `3.40` | [MikroTik Winbox](https://github.com/obeone/winbox-docker) in your browser — VNC-streamed, Wine-powered. |
 
-## MKTXP
+> 💡 Each chart ships with a per-folder `README.md` and a `values.yaml` annotated for [helm-docs](https://github.com/norwoodj/helm-docs).
 
-A Prometheus metrics exporter for Mikrotik's RouterOS
-[[Sources]](https://github.com/akpw/mktxp) [[Chart]](charts/mktxp)
+---
 
-## DNSCrypt proxy
+## 🔐 Provenance
 
-A flexible DNS proxy, with support for encrypted DNS protocols. [[Sources]](https://github.com/klutchell/dnscrypt-proxy-docker) [[Chart]](charts/dnscrypt-proxy)
+Every chart is signed with the GPG key `helm@obeone.org`:
 
-## Technitium DNSServer
+```text
+B9FE852F28888D27F8C9A11CD33E04CD22E335CE
+```
 
-Technitium DNS Server is a DNS that can be use as a piHole or AdGuardHome replacement. It can also be used as authoritative server
-[[Sources]](https://github.com/TechnitiumSoftware/DnsServer) [[Chart]](charts/technitium-dnsserver)
+Import the [public key](public_key.gpg) and verify on install:
 
-## Fooocus
+```console
+gpg --import public_key.gpg
+helm install <release> obeone/<chart> --verify
+```
 
-Fooocus is an open-source AI art generation model, based on LCM (Latent Consistency Model). It's designed to be user-friendly and accessible for everyone.
-[[Sources]](https://github.com/lllyasviel/fooocus) [[Chart]](charts/fooocus)
+---
 
-## OpenGist
+## 🛠️ Contributing
 
-Opengist is a self-hosted Pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface. It is similar to GitHub Gist, but open-source and could be self-hosted.
-[[Sources]](https://github.com/thomiceli/opengist) [[Chart]](charts/opengist)
+Per-chart docs live under `charts/<name>/README.md`. When editing a chart:
 
-## LibreTranslate
+1. If `Chart.yaml` changes — run `helm dep up charts/<name>`.
+2. Run `helm lint charts/<name>` and fix every warning before committing.
+3. Bump `version:` in `Chart.yaml` (chart-releaser only ships new versions)
+   and add an entry under `annotations.artifacthub.io/changes`.
 
-LibreTranslate is a free and open-source machine translation service that can be used as an alternative to Google Translate. It supports multiple languages, GPU acceleration for faster translations, and offline capabilities. The API allows developers to integrate translation functionality into their own projects.
-[[Sources]](https://github.com/LibreTranslate/LibreTranslate) [[Chart]](charts/libretranslate)
+Releases are cut automatically by
+[`chart-releaser-action`](.github/workflows/release.yml) on every push to `main`.
 
-## Transfer.sh
+---
 
-Transfer.sh is a simple file sharing service that allows users to upload files and share them via a URL. It supports various storage providers like S3, Google Drive, etc., and can be customized using environment variables.
-[[Sources]](https://github.com/dutchcoders/transfer.sh) [[Chart]](charts/transfer.sh)
-
-## Olvid Bot
-
-Olvid bot-daemon — a bridge service that lets you automate interactions with Olvid secure-messaging groups.
-[[Sources]](https://gitlab.com/olvid/olvid) [[Chart]](charts/olvid-bot)
+Made with ❤️ and a healthy dose of YAML by [**@obeone**](https://github.com/obeone).


### PR DESCRIPTION
## Summary

- Rewrite the repo-level `README.md`: shields.io badges, quick-start block, compact charts table with category emojis, GPG provenance section, contributing checklist.
- List only currently-released charts (uncommitted ones excluded).
- Add `.markdownlint.json` disabling MD013 so the badge / table lines pass lint.

## Test plan

- [x] `markdownlint README.md`
- [ ] Visual review on GitHub once the PR is open