### PR TITLE
chore(technitium-dnsserver): bump to appVersion 15.2.0 + rewrite NOTES.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ helm install my-release obeone/<chart> --verify
 | 📂 | [**nfs-server**](charts/nfs-server) | `2.2.2` | Lightweight, multi-arch [containerized NFS server](https://github.com/obeone/docker-nfs-server). |
 | 💬 | [**olvid-bot**](charts/olvid-bot) | `1.5.0` | [Olvid bot-daemon](https://gitlab.com/olvid/olvid) — bridge to automate Olvid secure-messaging groups. |
 | 📝 | [**opengist**](charts/opengist) | `1.10.0` | [Opengist](https://github.com/thomiceli/opengist) — self-hosted, Git-backed Pastebin / GitHub Gist alternative. |
-| 🌐 | [**technitium-dnsserver**](charts/technitium-dnsserver) | `15.1.0` | [Technitium DNS Server](https://github.com/TechnitiumSoftware/DnsServer) — recursive / authoritative DNS, PiHole & AdGuard alternative. |
+| 🌐 | [**technitium-dnsserver**](charts/technitium-dnsserver) | `15.2.0` | [Technitium DNS Server](https://github.com/TechnitiumSoftware/DnsServer) — recursive / authoritative DNS, PiHole & AdGuard alternative. |
 | 📤 | [**transfer.sh**](charts/transfer.sh) | `v1.6.1` | [transfer.sh](https://github.com/dutchcoders/transfer.sh) — CLI-friendly file-sharing with pluggable storage backends. |
 | 🪟 | [**winbox**](charts/winbox) | `3.40` | [MikroTik Winbox](https://github.com/obeone/winbox-docker) in your browser — VNC-streamed, Wine-powered. |
 

--- a/charts/technitium-dnsserver/Chart.yaml
+++ b/charts/technitium-dnsserver/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - pihole
   - adguard
 
-version: 1.10.0
-appVersion: "15.1.0"
+version: 1.11.0
+appVersion: "15.2.0"
 
 icon: https://raw.githubusercontent.com/obeone/charts/main/logo/technitium-dnsserver.png
 sources:
@@ -33,4 +33,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to 15.1.0
+      description: Update appVersion to 15.2.0

--- a/charts/technitium-dnsserver/README.md
+++ b/charts/technitium-dnsserver/README.md
@@ -1,6 +1,6 @@
 # Technitium DNS Server Helm Chart
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.1.0](https://img.shields.io/badge/AppVersion-15.1.0-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.2.0](https://img.shields.io/badge/AppVersion-15.2.0-informational?style=flat-square)
 
 Technitium DNS Server is a powerful and versatile DNS solution that can serve multiple purposes, from enhancing your network security by blocking ads and trackers (similar to Pi-hole or AdGuardHome) to acting as a robust authoritative DNS server for your domains. This Helm chart simplifies its deployment on Kubernetes, allowing you to leverage its advanced features with ease.
 

--- a/charts/technitium-dnsserver/templates/NOTES.txt
+++ b/charts/technitium-dnsserver/templates/NOTES.txt
@@ -1,53 +1,63 @@
 {{- $fullName := include "common.names.fullname" . -}}
-{{- $namespace := .Release.Namespace | quote -}}
-{{- $servicePort := .Values.service.main.ports.http.port -}}
-{{- $serviceType := .Values.service.main.type -}}
-{{- $clusterIP := "" }}
-{{- /* Attempt to get ClusterIP if service type is ClusterIP */ -}}
-{{- if eq $serviceType "ClusterIP" }}
-  {{- /* Note: .Values.service.main.clusterIPs might not be set directly, service might get one assigned. */ -}}
-  {{- /* This part is simplified and might need adjustment based on actual cluster state */ -}}
-{{- end }}
-{{- $loadBalancerIP := "" }}
-{{- /* Get LoadBalancer IP if specified */ -}}
-{{- if eq $serviceType "LoadBalancer" }}
-  {{- $loadBalancerIP = .Values.service.main.loadBalancerIP }}
-{{- end }}
-{{- $nodePort := "" }}
-{{- /* Get NodePort if specified */ -}}
-{{- if eq $serviceType "NodePort" }}
-  {{- $nodePort = .Values.service.main.ports.http.nodePort }}
-{{- end }}
+{{- $namespace := .Release.Namespace -}}
+{{- $svc := .Values.service.main -}}
+{{- $httpPort := $svc.ports.http.port -}}
+{{- $httpsPort := $svc.ports.https.port -}}
+{{- $dnsPort := (index $svc.ports "dns-udp").port -}}
+{{- $dohPort := (index $svc.ports "doh-reverse").port -}}
 
-Technitium DNS Server can be accessed as follows:
+Technitium DNS Server is deploying.
 
-{{- if eq $serviceType "LoadBalancer" }}
-  {{- if $loadBalancerIP }}
-    NOTE: You specified a LoadBalancer IP: http://{{ $loadBalancerIP }}:{{ $servicePort }}
-  {{- else }}
-    NOTE: Get the LoadBalancer IP for the service '{{ $fullName }}' in namespace '{{ $namespace }}':
-          kubectl get svc --namespace {{ $namespace }} {{ $fullName }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-    Then access: http://<LoadBalancerIP>:{{ $servicePort }}
-  {{- end }}
-{{- else if eq $serviceType "NodePort" }}
-  {{- if $nodePort }}
-    NOTE: Get the IP of any Node in your cluster:
-          kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}'
-    Then access: http://<NodeIP>:{{ $nodePort }}
-  {{- else }}
-    NOTE: Service Type is NodePort, but the nodePort is not explicitly set in values. Check the assigned port:
-          kubectl get svc --namespace {{ $namespace }} {{ $fullName }} -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}'
-    Then access using Node IP and the obtained port.
-  {{- end }}
-{{- else if eq $serviceType "ClusterIP" }}
-  NOTE: Access from within the cluster:
-        http://{{ $fullName }}.{{ $namespace }}.svc.cluster.local:{{ $servicePort }}
-
-  NOTE: Or setup port forwarding:
-        kubectl port-forward --namespace {{ $namespace }} svc/{{ $fullName }} {{ $servicePort }}:{{ $servicePort }}
-  Then access: http://localhost:{{ $servicePort }}
+== Admin web UI ==
+{{- if and .Values.ingress.main.enabled (gt (len .Values.ingress.main.hosts) 0) }}
+{{- $hasTLS := gt (len (default (list) .Values.ingress.main.tls)) 0 }}
+{{- $scheme := ternary "https" "http" $hasTLS }}
+{{- range .Values.ingress.main.hosts }}
+{{- $host := .host }}
+{{- range .paths }}
+  {{ $scheme }}://{{ $host }}{{ .path }}
+{{- end }}
+{{- end }}
+{{- else if eq $svc.type "LoadBalancer" }}
+{{- if $svc.loadBalancerIP }}
+  http://{{ $svc.loadBalancerIP }}:{{ $httpPort }}
 {{- else }}
-  NOTE: Service type '{{ $serviceType }}' configured. Access method depends on your cluster setup.
+  Wait for the LoadBalancer to be assigned:
+    kubectl get svc -n {{ $namespace }} {{ $fullName }} -w
+  Then browse: http://<EXTERNAL-IP>:{{ $httpPort }}
+{{- end }}
+{{- else if eq $svc.type "NodePort" }}
+{{- $nodePort := $svc.ports.http.nodePort }}
+  Get any node IP:
+    kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}'
+{{- if $nodePort }}
+  Then browse: http://<NODE-IP>:{{ $nodePort }}
+{{- else }}
+  Get the assigned NodePort:
+    kubectl get svc -n {{ $namespace }} {{ $fullName }} -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}'
+{{- end }}
+{{- else }}
+  In-cluster:  http://{{ $fullName }}.{{ $namespace }}.svc.cluster.local:{{ $httpPort }}
+  Port-forward from your laptop:
+    kubectl port-forward -n {{ $namespace }} svc/{{ $fullName }} {{ $httpPort }}:{{ $httpPort }}
+  Then browse: http://localhost:{{ $httpPort }}
 {{- end }}
 
-Check the Technitium DNS Server documentation for initial setup and credentials if needed.
+Default credentials: admin / admin  -- change them on first login.
+
+== DNS endpoint ==
+  In-cluster: {{ $fullName }}.{{ $namespace }}.svc.cluster.local:{{ $dnsPort }}
+{{- if eq $svc.type "LoadBalancer" }}
+  External:   point your resolver / clients at the Service external IP on port {{ $dnsPort }} (UDP + TCP).
+{{- else if eq $svc.type "NodePort" }}
+  External:   the DNS port is exposed as a NodePort -- check it with:
+    kubectl get svc -n {{ $namespace }} {{ $fullName }}
+{{- end }}
+
+Additional protocols exposed by the Service (when enabled):
+  HTTPS UI : {{ $httpsPort }}
+  DoT      : {{ $svc.ports.dot.port }}
+  DoH proxy: {{ $dohPort }}
+  DHCP     : {{ $svc.ports.dhcp.port }}/udp
+
+See https://technitium.com/dns/ for setup and configuration.


### PR DESCRIPTION
## Summary

- Bump `technitium-dnsserver` chart to `1.11.0` / appVersion `15.2.0`.
- Rewrite `NOTES.txt`: drop dead `$clusterIP` block, prefer ingress hosts for the admin UI when enabled, expose the DNS service endpoint separately, list extra protocol ports (HTTPS, DoT, DoH proxy, DHCP), and remind users of the default `admin/admin` credentials.
- Update root README index and per-chart README badges.

## Test plan

- [x] `helm dep up charts/technitium-dnsserver`
- [x] `helm lint charts/technitium-dnsserver` → 0 failed
- [x] `helm install --dry-run` → NOTES.txt renders cleanly with all branches reachable