### PR TITLE
docs(readme): list ollama in chart index

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ helm install my-release obeone/<chart> --verify
 | 🌍 | [**libretranslate**](charts/libretranslate) | `v1.6.5` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
 | 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |
 | 📂 | [**nfs-server**](charts/nfs-server) | `2.2.2` | Lightweight, multi-arch [containerized NFS server](https://github.com/obeone/docker-nfs-server). |
+| 🦙 | [**ollama**](charts/ollama) | `latest` | [Ollama](https://ollama.com) — run LLMs locally, with an optional single-switch transparent Prometheus exporter/proxy sidecar (cosign-signed). GPU-accelerated, multi-arch. |
 | 💬 | [**olvid-bot**](charts/olvid-bot) | `1.5.0` | [Olvid bot-daemon](https://gitlab.com/olvid/olvid) — bridge to automate Olvid secure-messaging groups. |
 | 📝 | [**opengist**](charts/opengist) | `1.10.0` | [Opengist](https://github.com/thomiceli/opengist) — self-hosted, Git-backed Pastebin / GitHub Gist alternative. |
 | 🌐 | [**technitium-dnsserver**](charts/technitium-dnsserver) | `15.2.0` | [Technitium DNS Server](https://github.com/TechnitiumSoftware/DnsServer) — recursive / authoritative DNS, PiHole & AdGuard alternative. |


### PR DESCRIPTION
## Summary

Add the `ollama` chart to the chart index table in the root README, placed alphabetically between `nfs-server` and `olvid-bot`. Highlights the single-switch optional cosign-signed exporter/proxy sidecar and GPU support.

## Test plan

- Visual: new row renders in the index table, link points to `charts/ollama`.