### PR TITLE
fix: repair release pipeline and clear Artifact Hub scan errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5
         with:
           version: 3.8.1
 
@@ -50,7 +50,7 @@ jobs:
           helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
           charts_repo_url: ${{  env.URL }}

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -12,4 +12,19 @@
 repositoryID: fb8b2f65-3902-417f-b1d4-23d05039bc1c
 owners: # (optional, used to claim repository ownership)
   - name: obeone
-    email: obeone@obeone.org 
+    email: obeone@obeone.org
+
+# Packages/versions Artifact Hub should not index or scan.
+#
+# These superseded chart versions pin upstream image tags that have since been
+# deleted from their registries, so Artifact Hub's image scanner cannot pull
+# them and reports "image not found". The current chart versions reference tags
+# that still exist (mktxp -> :latest, technitium-dnsserver -> :15.2.0), so only
+# these old releases are affected. Ignoring them clears the scan errors WITHOUT
+# removing them from the Helm index — they stay installable via
+# `helm install --version <x>`. `version` is an RE2 regular expression.
+ignore:
+  - name: mktxp
+    version: ^1\.1\.8$ # pins ghcr.io/akpw/mktxp:v1.2.17 (deleted upstream)
+  - name: technitium-dnsserver
+    version: ^1\.5\.3$ # pins technitium/dns-server:13.5 (deleted upstream)


### PR DESCRIPTION
## Summary

Two independent repo-infrastructure fixes, both surfaced after the firecrawl 2.0.0 release.

### 1. Release pipeline (`ci(release)`)
`helm/chart-releaser-action@v1.4.0` mishandles provenance (`.prov`) files in its `cr index` step: it doubles the `.tgz` extension and treats signed chart packages as non-charts (`... is not a helm chart package ... got 'text/plain'`). This has failed **every** release since GPG signing was enabled (incl. the firecrawl 2.0.0 publish, which created the GitHub release + tag but never updated `index.yaml`).

- `helm/chart-releaser-action` v1.4.0 -> **v1.7.0** (fixes `.prov` indexing)
- `actions/checkout` v3 -> **v6**, `azure/setup-helm` v3 -> **v5** (clear deprecated-runtime warnings)

Once merged, the push-to-main release run regenerates `index.yaml` and finally publishes **firecrawl 2.0.0** (and any other unindexed versions).

### 2. Artifact Hub scan errors (`chore(artifacthub)`)
The scanner reports `image not found` for two superseded versions whose upstream image tags were deleted:

| Chart | Version | Pinned tag | Status |
| --- | --- | --- | --- |
| mktxp | 1.1.8 | `ghcr.io/akpw/mktxp:v1.2.17` | deleted upstream |
| technitium-dnsserver | 1.5.3 | `technitium/dns-server:13.5` | deleted upstream |

Current versions reference tags that still exist (`mktxp:latest`, `dns-server:15.2.0`). Added an `ignore` block to `artifacthub-repo.yml` for just those two versions — non-destructive: they remain in the Helm index and installable by explicit version.

## Test plan

- [x] `python -c yaml.safe_load` on both files — valid; `ignore` regexes intact
- [x] Verified live: `mktxp:latest` 200 / `v1.2.17` 404; `dns-server:15.2.0` 200 / `13.5` 404
- [x] Verified `artifacthub-repo.yml` is served at `https://charts.obeone.cloud/artifacthub-repo.yml`
- [x] Confirmed mktxp 1.1.9 and technitium 1.11.0 already published (fix only needed for historical versions)
- [ ] Post-merge: release run succeeds and `index.yaml` lists firecrawl 2.0.0
- [ ] Post-merge: Artifact Hub re-processes and the two scan errors clear