### PR TITLE
chore(firecrawl): bump to 2.0.1 to publish past stuck 2.0.0

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.0
+version: 2.0.1
 appVersion: "2.10.19"
 kubeVersion: ">=1.25.0-0"
 
@@ -51,3 +51,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Initial release — rebuilt on the bjw-s common library with the current self-hosted topology (NuQ queue, RabbitMQ, multi-worker split) and official ghcr.io images.
+    - kind: fixed
+      description: First installable release; the 2.0.0 tag was created but never reached the chart index due to a release-pipeline issue, so 2.0.1 supersedes it.

--- a/charts/firecrawl/README.md
+++ b/charts/firecrawl/README.md
@@ -1,6 +1,6 @@
 # Firecrawl
 
-![Version](https://img.shields.io/badge/version-2.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/badge/version-2.0.1-informational?style=flat-square)
 ![AppVersion](https://img.shields.io/badge/appVersion-2.10.19-informational?style=flat-square)
 ![Type](https://img.shields.io/badge/type-application-informational?style=flat-square)
 ![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)


### PR DESCRIPTION
## Summary

`firecrawl-2.0.0` was tagged and released on GitHub but never made it into the published Helm index (`index.yaml`) because of the release-pipeline bug fixed in #31. chart-releaser only processes charts that changed **since the latest tag**, so once `firecrawl-2.0.0` exists as a tag it reports "Nothing to do" and cannot re-index that version.

Bump the chart to **2.0.1** (content identical to the intended 2.0.0) so chart-releaser detects it, packages, signs and indexes it. 2.0.1 is therefore the first installable release; the orphan 2.0.0 release stays out of the index and is invisible to `helm` users.

## Changes
- `Chart.yaml`: `version` 2.0.0 -> 2.0.1; add `artifacthub.io/changes` note recording the supersession
- `README.md`: version badge 2.0.0 -> 2.0.1

## Test plan
- [x] `helm dep up charts/firecrawl` — deps unchanged (common 4.6.2), Chart.lock untouched
- [x] `helm lint charts/firecrawl` — 1 linted, 0 failed
- [ ] Post-merge: release run publishes `firecrawl-2.0.1` and it appears in `index.yaml`
- [ ] Post-merge: `helm repo update && helm search repo obeone/firecrawl` shows 2.0.1