### PR TITLE
refactor(ollama): ship portable defaults for the public release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository purpose
+
+Personal Helm chart repository published at <https://charts.obeone.cloud> and indexed on Artifact Hub. Each subdirectory of `charts/` is a self-contained, GPG-signed Helm chart packaging a self-hosted application (Winbox, CyberChef, Technitium DNS, DNSCrypt-proxy, Olvid bot, etc.).
+
+## Generic values — charts are public
+
+Every chart is published and meant to be reused by strangers. Anything shipped in a chart (`values.yaml` defaults, `values.schema.json` examples, README snippets) **must use generic placeholders**, never real or personal data:
+
+- Hosts/ingress/URLs → `example.com`, `chart-example.local`; IPs → documented ranges (`192.0.2.0/24`, `203.0.113.0/24`).
+- No real secrets, tokens, passwords, emails, internal hostnames, or cluster-specific names. Secrets default to empty/commented, with a `# --` comment telling the user to set them.
+- Defaults should be safe and work out of the box for an arbitrary cluster, not tuned to one environment.
+- No cluster-specific Service defaults. In particular, do **not** ship dual-stack (`ipFamilyPolicy: PreferDualStack` / `ipFamilies`) or `internalTrafficPolicy` in a chart's `values.yaml`: those are local cluster conventions, not portable defaults. Let Kubernetes apply its own defaults; mention such knobs only as commented examples if useful.
+- Don't bake personal performance/tuning constants into defaults (e.g. context length, parallelism, keep-alive timers). Ship the upstream app's own defaults and expose tuning knobs as commented examples.
+- `values_local.yaml` is the only place for real/ad-hoc values; it never ships in a release.
+
+(The repo's own identity — `charts.obeone.cloud`, the `helm@obeone.org` signing key — is legitimate repo metadata, not chart content; this rule is about what each chart hands to its users.)
+
+## Mandatory workflow when modifying a chart
+
+From `AGENTS.md` — these rules apply to every change, no exceptions:
+
+1. If `charts/<name>/Chart.yaml` is touched (dependency version, appVersion, etc.), run `helm dep up charts/<name>` to refresh `Chart.lock` and the `charts/` subdir.
+2. Before committing **any** chart change, run `helm lint charts/<name>` and fix every error/warning it surfaces.
+
+When bumping a chart, also bump `version:` in `Chart.yaml` (chart-releaser only publishes new versions) and add an entry under `annotations.artifacthub.io/changes`.
+
+## Chart anatomy
+
+Two common-library lineages coexist — check `Chart.yaml` dependencies before editing templates:
+
+- **k8s-at-home `common`** (`https://library-charts.k8s-at-home.com`, v4.x) — used by most charts (winbox, dnscrypt-proxy, technitium-dnsserver, cyberchef, fooocus, mktxp, opengist, libretranslate, transfer.sh, ...). Templates are typically a thin wrapper that just calls the common lib; configuration lives in `values.yaml`.
+- **bjw-s-labs `common`** (`https://bjw-s-labs.github.io/helm-charts`, v4.x) — used by newer charts (olvid-bot). Different values schema (controllers/services/persistence keys); do not copy values between the two lineages.  
+
+Per-chart files of note:
+- `values.yaml` — annotated with helm-docs-style `# --` comments; do not strip them.
+- `values.schema.json` — JSON Schema validated by Helm at install time; keep it in sync with new values you add.
+- `values_local.yaml` — local override used for ad-hoc testing; never used in releases.
+- `README_CONFIG.md.gotmpl` (when present) — helm-docs template; `README.md` is generated from it.
+
+## Release pipeline
+
+`.github/workflows/release.yml` runs on push to `main`:
+1. Fast-forwards `gh-pages` from `main`.
+2. Adds the upstream chart repos (`k8s-at-home`, `bitnami`, `bjw-s`) so `helm dep` can resolve.
+3. Runs `helm/chart-releaser-action` with `CR_SIGN=true` and the GPG key `helm@obeone.org` (provided via `secrets.GPG_PRIVATE_KEY`). `CR_SKIP_EXISTING=true` — bumping `version:` is required for a new release to appear.
+
+Public signing key fingerprint: `B9FE852F28888D27F8C9A11CD33E04CD22E335CE` (`public_key.gpg`).
+
+## Scope discipline
+
+- Edit only the chart(s) directly involved in the request. Don't sweep cosmetic changes across unrelated charts.
+- Prefer editing `values.yaml` over hard-coding in templates; most charts have no custom templates beyond `common.all`.

--- a/charts/ollama/Chart.yaml
+++ b/charts/ollama/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ollama
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"
 kubeVersion: ">=1.31.0-0"
 
@@ -10,8 +10,7 @@ description: >-
   (exporter.enabled): on, it fronts the API and exports /metrics; off, the
   API is served directly. This Helm chart packages the Ollama server on the
   bjw-s common library so behaviour is driven almost entirely from
-  values.yaml. Supports GPU acceleration via RuntimeClass and dual-stack
-  Services out of the box.
+  values.yaml. Supports GPU acceleration via RuntimeClass.
 
 type: application
 
@@ -48,5 +47,11 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial release — Ollama server with optional Prometheus exporter sidecar, GPU and dual-stack support
+    - kind: removed
+      description: Drop cluster-specific Service defaults (dual-stack ipFamilyPolicy/ipFamilies) so the chart ships portable defaults
+    - kind: changed
+      description: Stop hard-coding personal tuning constants (context length, keep-alive, parallelism, flash-attention); they are now commented examples and Ollama's own defaults apply
+    - kind: changed
+      description: Collapse the separate metrics Service port into the http port; metrics are scraped on http /metrics via the ServiceMonitor
+    - kind: changed
+      description: Switch liveness/readiness probes from tcpSocket to httpGet on /

--- a/charts/ollama/README.md
+++ b/charts/ollama/README.md
@@ -1,6 +1,6 @@
 # Ollama Helm Chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/ollama)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/ollama)
 
 ## What is Ollama?
 
@@ -46,12 +46,12 @@ controllers:
         enabled: false   # <-- the only line you touch
 ```
 
-| `exporter.enabled` | `http` Service port → targetPort | `metrics` port (`:8000`) | Sidecar container |
-|--------------------|----------------------------------|--------------------------|-------------------|
-| `true` (default)   | `11434 → 8000` (through proxy)    | present                  | present           |
-| `false`            | `11434 → 11434` (direct to Ollama)| dropped                  | dropped           |
+| `exporter.enabled` | `http` Service port → targetPort | `/metrics` | Sidecar container |
+|--------------------|----------------------------------|------------|-------------------|
+| `true` (default)   | `11434 → 8000` (through proxy)    | scraped on the `http` port | present           |
+| `false`            | `11434 → 11434` (direct to Ollama)| none       | dropped           |
 
-So when you disable it, the API keeps working — traffic just goes straight to Ollama and there is no dangling `:8000` Service port left pointing at a container that no longer exists. No other value needs changing.
+So when you disable it, the API keeps working — traffic just goes straight to Ollama, the `http` Service port simply retargets to `11434`, and there is nothing left pointing at a container that no longer exists. No other value needs changing.
 
 > ℹ️ The default ships the proxy **on**. If you have no metrics/proxy image to run, set `exporter.enabled: false` and Ollama is served directly.
 
@@ -111,8 +111,8 @@ controllers:
           repository: ollama/ollama
           tag: "0.6.0"              # pin for reproducibility
         env:
+          # Optional tuning overrides; unset by default (Ollama's own defaults apply)
           OLLAMA_KEEP_ALIVE: 30m
-          OLLAMA_CONTEXT_LENGTH: "64000"
         resources:
           requests:
             memory: 10Gi            # bump to fit your models
@@ -146,11 +146,11 @@ serviceMonitor:
 |----------------------------------------------------------------|--------|------------------|---------------------------------------------------|
 | controllers.main.containers.ollama.image.repository            | string | `ollama/ollama`  | Ollama server image                               |
 | controllers.main.containers.ollama.image.tag                  | string | `latest`         | Image tag — pin to a release for reproducibility  |
-| controllers.main.containers.ollama.env.OLLAMA_KEEP_ALIVE       | string | `30m`            | How long a model stays loaded after the last call |
-| controllers.main.containers.ollama.env.OLLAMA_NUM_PARALLEL     | string | `"2"`            | Parallel requests per model                       |
-| controllers.main.containers.ollama.env.OLLAMA_MAX_LOADED_MODELS| string | `"4"`            | Max models kept loaded simultaneously             |
-| controllers.main.containers.ollama.env.OLLAMA_CONTEXT_LENGTH   | string | `"64000"`        | Default context window size                       |
-| controllers.main.containers.ollama.env.OLLAMA_FLASH_ATTENTION  | string | `"true"`         | Enable Flash Attention                            |
+| controllers.main.containers.ollama.env.OLLAMA_HOST            | string | `"0.0.0.0"`      | Bind address; must stay reachable in-cluster      |
+| controllers.main.containers.ollama.env.OLLAMA_ORIGINS         | string | `"*"`            | Allowed CORS origins                              |
+| controllers.main.containers.ollama.env.OLLAMA_NOHISTORY       | string | `"true"`         | Disable prompt history persistence                |
+
+Performance/tuning knobs (`OLLAMA_KEEP_ALIVE`, `OLLAMA_NUM_PARALLEL`, `OLLAMA_MAX_LOADED_MODELS`, `OLLAMA_SCHED_SPREAD`, `OLLAMA_FLASH_ATTENTION`) ship **commented out** in `values.yaml`, so Ollama's own upstream defaults apply. Uncomment and adjust them to your hardware and workload.
 
 ### Exporter / proxy sidecar
 
@@ -166,9 +166,7 @@ serviceMonitor:
 | Key                                          | Type   | Default          | Description                                                  |
 |----------------------------------------------|--------|------------------|-------------------------------------------------------------|
 | service.main.type                            | string | `ClusterIP`      | Service type                                                |
-| service.main.ipFamilyPolicy                  | string | `PreferDualStack`| Dual-stack, degrades to single-stack                        |
-| service.main.ports.http.port                 | int    | `11434`          | API port; `targetPort` is managed by `exporter.enabled`     |
-| service.main.ports.metrics.port              | int    | `8000`           | Exporter `/metrics` port (dropped when the exporter is off) |
+| service.main.ports.http.port                 | int    | `11434`          | API port; `targetPort` is managed by `exporter.enabled` (`/metrics` is scraped on this port via the ServiceMonitor) |
 
 ### Persistence
 
@@ -202,11 +200,11 @@ helm upgrade ollama obeone/ollama --reuse-values \
   --set serviceMonitor.metrics.enabled=true
 ```
 
-Disabling the exporter (`exporter.enabled=false`) removes both the sidecar and the `metrics` port, so leave the `ServiceMonitor` off in that case.
+Disabling the exporter (`exporter.enabled=false`) removes the sidecar, and with it `/metrics`, so leave the `ServiceMonitor` off in that case.
 
 ## GPU notes
 
-GPU exposure is effective only when `defaultPodOptions.runtimeClassName` points at an NVIDIA RuntimeClass. The `ollama` container already carries `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility`, plus `OLLAMA_SCHED_SPREAD=1` to spread work across all GPUs. For [Sablier](https://acouvreur.github.io/sablier/) scale-to-zero on a GPU group, set pod labels under `controllers.main.pod.labels`.
+GPU exposure is effective only when `defaultPodOptions.runtimeClassName` points at an NVIDIA RuntimeClass. The `ollama` container already carries `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility`. To spread work across all GPUs, uncomment `OLLAMA_SCHED_SPREAD=1` in `values.yaml` (it ships commented out alongside the other tuning knobs). For [Sablier](https://acouvreur.github.io/sablier/) scale-to-zero on a GPU group, set pod labels under `controllers.main.pod.labels`.
 
 ## Upgrading
 

--- a/charts/ollama/templates/common.yaml
+++ b/charts/ollama/templates/common.yaml
@@ -13,12 +13,11 @@ global:
 {{- /* Single switch for the metrics/proxy sidecar: the exporter container's
        own `enabled`. The exporter is a transparent proxy sitting in the API
        path, so when it is disabled we must also send the http Service port
-       straight to Ollama (11434) and drop the now-backendless metrics port.
+       straight to Ollama (11434) instead of the exporter's proxy port.
        Default (no `enabled` key) keeps the exporter on and http -> :8000. */ -}}
 {{- $exporter := dig "controllers" "main" "containers" "exporter" dict .Values -}}
 {{- if and (hasKey $exporter "enabled") (not $exporter.enabled) -}}
   {{- $_ := set (dig "service" "main" "ports" "http" dict .Values) "targetPort" 11434 -}}
-  {{- $_ := set (dig "service" "main" "ports" "metrics" dict .Values) "enabled" false -}}
 {{- end -}}
 
 {{/* Render the templates */}}

--- a/charts/ollama/values.yaml
+++ b/charts/ollama/values.yaml
@@ -38,20 +38,20 @@ controllers:
           OLLAMA_HOST: "0.0.0.0"
           # -- Allowed CORS origins.
           OLLAMA_ORIGINS: "*"
+          # Performance/tuning knobs left to Ollama's own upstream defaults.
+          # Uncomment and adjust to your hardware and workload:
           # -- How long a model stays loaded in memory after the last request.
-          OLLAMA_KEEP_ALIVE: 30m
+          # OLLAMA_KEEP_ALIVE: 30m
           # -- Number of parallel requests handled per model.
-          OLLAMA_NUM_PARALLEL: "2"
+          # OLLAMA_NUM_PARALLEL: "2"
           # -- Maximum number of models kept loaded simultaneously.
-          OLLAMA_MAX_LOADED_MODELS: "4"
+          # OLLAMA_MAX_LOADED_MODELS: "4"
           # -- Spread work across all GPUs.
-          OLLAMA_SCHED_SPREAD: "1"
+          # OLLAMA_SCHED_SPREAD: "1"
           # -- Enable Flash Attention.
-          OLLAMA_FLASH_ATTENTION: "true"
+          # OLLAMA_FLASH_ATTENTION: "true"
           # -- Disable prompt history persistence.
           OLLAMA_NOHISTORY: "true"
-          # -- Default context window size.
-          OLLAMA_CONTEXT_LENGTH: "64000"
           # -- Scratch directory (mounted as an emptyDir below).
           OLLAMA_TMPDIR: /tmp/ollama
           # GPU exposure — effective only when defaultPodOptions.runtimeClassName
@@ -63,7 +63,8 @@ controllers:
             enabled: true
             custom: true
             spec:
-              tcpSocket:
+              httpGet:
+                path: /
                 port: 11434
               initialDelaySeconds: 30
               periodSeconds: 15
@@ -73,7 +74,8 @@ controllers:
             enabled: true
             custom: true
             spec:
-              tcpSocket:
+              httpGet:
+                path: /
                 port: 11434
               initialDelaySeconds: 10
               periodSeconds: 10
@@ -111,6 +113,9 @@ controllers:
         env:
           # -- Upstream Ollama URL the exporter proxies to (same pod, localhost).
           OLLAMA_HOST: http://localhost:11434
+        ports:
+          - name: proxy
+            containerPort: 8000
         probes:
           liveness:
             enabled: true
@@ -139,20 +144,12 @@ service:
   main:
     controller: main
     type: ClusterIP
-    # -- Prefer dual-stack; degrades gracefully to single-stack clusters.
-    ipFamilyPolicy: PreferDualStack
-    ipFamilies:
-      - IPv4
-      - IPv6
     ports:
       http:
         primary: true
         port: 11434
         protocol: HTTP
-        targetPort: 8000
-      metrics:
-        port: 8000
-        protocol: HTTP
+        targetPort: proxy
 
 ingress:
   main:
@@ -207,7 +204,7 @@ serviceMonitor:
     enabled: false
     serviceName: '{{ include "bjw-s.common.lib.chart.names.fullname" $ }}'
     endpoints:
-      - port: metrics
+      - port: http
         path: /metrics
         interval: 30s
         scrapeTimeout: 10s


### PR DESCRIPTION
## Summary

The `ollama` chart shipped values tuned to my own cluster, which is wrong for a public chart that strangers reuse. This makes it portable and bumps it to 0.2.0.

- Drop dual-stack Service defaults (`ipFamilyPolicy`/`ipFamilies`) so Service IP families fall back to Kubernetes defaults.
- Comment out the performance/tuning constants (keep-alive, parallelism, max loaded models, GPU spread, flash-attention) and remove the hard-coded context length, so Ollama's own upstream defaults apply. They stay in `values.yaml` as commented examples.
- Collapse the separate metrics Service port into the `http` port. Metrics are now scraped on `http` `/metrics` through the ServiceMonitor.
- Switch liveness/readiness probes from `tcpSocket` to `httpGet` on `/`.
- Refresh the README (badge, parameter tables, exporter toggle table, GPU notes) and the changelog.

Also adds a repo guidance file forbidding cluster-specific and personal defaults in any public chart, so this does not creep back in.

## Test plan

- `helm dep up charts/ollama` (lock unchanged)
- `helm lint charts/ollama` passes with 0 failures
- `helm template` renders correctly with the exporter on (http -> proxy:8000) and off (http -> 11434), with no leftover metrics port