### PR TITLE
chore(ci): bump release workflow action and tool versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --dearmor --output keyring.gpg
 
       - name: Merge main -> gh-pages
-        uses: devmasx/merge-branch@master
+        uses: devmasx/merge-branch@v1.4.0
         with:
           type: now
           target_branch: gh-pages
@@ -41,7 +41,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: 3.8.1
+          version: 3.21.2
 
       - name: Helm Deps
         run: |


### PR DESCRIPTION
## Summary

Refresh the pinned versions in the release workflow.

- `actions/checkout` v6 -> v7 (latest major)
- `devmasx/merge-branch` pinned from `@master` to `@v1.4.0` for a reproducible, non-floating reference (this step touches `gh-pages`, so a moving tag is a real risk)
- Helm 3.8.1 -> 3.21.2, staying on the 3.x branch on purpose to avoid the Helm 4 major break that chart-releaser is not guaranteed to support

`azure/setup-helm@v5` and `helm/chart-releaser-action@v1.7.0` were already on the latest release, left untouched.

## Test plan

- YAML syntax validated locally
- The workflow runs on push to `main`, so the next merge exercises checkout, the gh-pages merge, Helm setup and chart-releaser end to end. The Helm bump is the only behavioral change worth watching.