### PR TITLE
feat: bump chart appVersions (cloakbrowser-mcp, cyberchef, opengist, libretranslate)

### DIFF
--- a/charts/cloakbrowser-mcp/Chart.yaml
+++ b/charts/cloakbrowser-mcp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cloakbrowser-mcp
-version: 0.1.0
-appVersion: "1.5.0"
+version: 0.1.1
+appVersion: "1.6.0"
 kubeVersion: ">=1.31.0-0"
 
 description: >-
@@ -44,5 +44,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial release of the cloakbrowser-mcp chart (appVersion 1.5.0)
+    - kind: changed
+      description: Update appVersion to 1.6.0

--- a/charts/cyberchef/Chart.yaml
+++ b/charts/cyberchef/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v11.0.0
+appVersion: v11.2.0
 description: GCHQ CyberChef [multi-arch]
 name: cyberchef
-version: 2.0.0
+version: 2.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - cyberchef
@@ -21,4 +21,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to v11.0.0
+      description: Update appVersion to v11.2.0

--- a/charts/cyberchef/README.md
+++ b/charts/cyberchef/README.md
@@ -1,6 +1,6 @@
 # CyberChef Helm Chart
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v11.0.0](https://img.shields.io/badge/AppVersion-v11.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cyberchef)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: v11.2.0](https://img.shields.io/badge/AppVersion-v11.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cyberchef)
 
 ## What is CyberChef?
 

--- a/charts/libretranslate/Chart.yaml
+++ b/charts/libretranslate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.6.5
+appVersion: v1.9.6
 description: Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup.
 name: libretranslate
-version: 1.0.4
+version: 1.0.5
 kubeVersion: ">=1.16.0-0"
 keywords:
   - libretranslate
@@ -28,6 +28,6 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: AppVersion updated
-    - kind: added
-      description: values schema
+      description: Update appVersion to v1.9.6
+    - kind: fixed
+      description: Fix persistence volumes to use bjw-s common globalMounts

--- a/charts/libretranslate/README.md
+++ b/charts/libretranslate/README.md
@@ -1,6 +1,6 @@
 # libretranslate
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: v1.6.5](https://img.shields.io/badge/AppVersion-v1.6.5-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
 
 Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup.
 
@@ -25,7 +25,7 @@ Kubernetes: `>=1.16.0-0`
 | controllers.main.containers.main.env.LT_UPDATE_MODELS | string | `"1"` | Set to "1" to update language models on startup |
 | controllers.main.containers.main.image.pullPolicy | string | `"Always"` | Image pull policy (Always, IfNotPresent, Never) |
 | controllers.main.containers.main.image.repository | string | `"libretranslate/libretranslate"` | Image repository to pull |
-| controllers.main.containers.main.image.tag | string | `"v1.6.5"` | Image tag to pull (use vX.X.X-cuda for GPU builds) |
+| controllers.main.containers.main.image.tag | string | `"v1.9.6"` | Image tag to pull (use vX.X.X-cuda for GPU builds) |
 | controllers.main.containers.main.probes.liveness.custom | bool | `true` |  |
 | controllers.main.containers.main.probes.liveness.enabled | bool | `true` |  |
 | controllers.main.containers.main.probes.liveness.spec.httpGet.path | string | `"/"` |  |
@@ -43,7 +43,7 @@ Kubernetes: `>=1.16.0-0`
 | ingress.main.enabled | bool | `false` | Enable or disable ingress |
 | ingress.main.tls[0].secretName | string | `"tls-chart-example-local"` | Secret containing TLS certificate for the ingress |
 | nodeSelector | object | `{}` | Node selector for pod assignment |
-| persistence | object | `{"api-keys":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"globalMounts":[{"path":"/app/db"}],"size":"10Mi"},"cache":{"cpuPath":"/home/libretranslate/.local/cache","enabled":true,"gpuPath":"/root/.cache/libretranslate","type":"emptyDir"},"db":{"accessMode":"ReadWriteOnce","annotations":{},"cpuPath":"/home/libretranslate/.local/db","enabled":false,"gpuPath":"/root/.local/db","size":"1Gi"},"files-translate":{"enabled":true,"path":"/tmp/libretranslate-files-translate","type":"emptyDir"},"share":{"accessMode":"ReadWriteOnce","annotations":{},"cpuPath":"/home/libretranslate/.local/share","enabled":true,"gpuPath":"/root/.local/share","size":"20Gi"}}` | Persistence volumes configuration for different data types Paths are statically defined here. Template logic must occur in templates. |
+| persistence | object | `{"api-keys":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"globalMounts":[{"path":"/app/db"}],"size":"10Mi"},"cache":{"enabled":true,"globalMounts":[{"path":"/home/libretranslate/.local/cache"}],"type":"emptyDir"},"db":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"globalMounts":[{"path":"/home/libretranslate/.local/db"}],"size":"1Gi"},"files-translate":{"enabled":true,"globalMounts":[{"path":"/tmp/libretranslate-files-translate"}],"type":"emptyDir"},"share":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":true,"globalMounts":[{"path":"/home/libretranslate/.local/share"}],"size":"20Gi"}}` | Persistence volumes configuration for different data types |
 | persistence.api-keys.enabled | bool | `false` | Enable persistence for API keys database |
 | persistence.cache.enabled | bool | `true` | Enable temporary cache storage |
 | persistence.db.enabled | bool | `false` | Enable database storage for application data |

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -17,7 +17,7 @@ controllers:
           # -- Image repository to pull
           repository: libretranslate/libretranslate
           # -- Image tag to pull (use vX.X.X-cuda for GPU builds)
-          tag: v1.6.5
+          tag: v1.9.6
           # -- Image pull policy (Always, IfNotPresent, Never)
           pullPolicy: Always
 
@@ -86,7 +86,6 @@ ingress:
         secretName: tls-chart-example-local
 
 # -- Persistence volumes configuration for different data types
-# Paths are statically defined here. Template logic must occur in templates.
 persistence:
   api-keys:
     # -- Enable persistence for API keys database
@@ -101,8 +100,8 @@ persistence:
     # -- Enable temporary cache storage
     enabled: true
     type: emptyDir
-    cpuPath: /home/libretranslate/.local/cache
-    gpuPath: /root/.cache/libretranslate
+    globalMounts:
+      - path: /home/libretranslate/.local/cache
 
   db:
     # -- Enable database storage for application data
@@ -110,8 +109,8 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
     annotations: {}
-    cpuPath: /home/libretranslate/.local/db
-    gpuPath: /root/.local/db
+    globalMounts:
+      - path: /home/libretranslate/.local/db
 
   share:
     # -- Enable persistent shared storage for translation models and shared assets
@@ -119,14 +118,15 @@ persistence:
     accessMode: ReadWriteOnce
     size: 20Gi
     annotations: {}
-    cpuPath: /home/libretranslate/.local/share
-    gpuPath: /root/.local/share
+    globalMounts:
+      - path: /home/libretranslate/.local/share
 
   files-translate:
     # -- Temporary storage for uploaded translation files
     enabled: true
     type: emptyDir
-    path: /tmp/libretranslate-files-translate
+    globalMounts:
+      - path: /tmp/libretranslate-files-translate
 
 # -- Define additional volumes if needed
 additionalVolumes: []

--- a/charts/opengist/Chart.yaml
+++ b/charts/opengist/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opengist
-version: 1.1.0
-appVersion: 1.10.0
+version: 1.1.1
+appVersion: 1.13.1
 kubeVersion: ">=1.16.0-0"
 
 description: >-
@@ -42,4 +42,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: appVersion
+      description: Update appVersion to 1.13.1

--- a/charts/opengist/README.md
+++ b/charts/opengist/README.md
@@ -1,6 +1,6 @@
 # Opengist Helm Chart
 
-![Version](https://img.shields.io/badge/version-1.1.0-informational?style=flat-square)
+![Version](https://img.shields.io/badge/version-1.1.1-informational?style=flat-square)
 
 OpenGist is a self-hosted Pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface.
 


### PR DESCRIPTION
Checked every chart against its upstream and bumped the ones lagging behind. Only bumped when the target Docker image tag actually exists, not just the git tag.

## appVersion bumps

- cloakbrowser-mcp: 1.5.0 to 1.6.0
- cyberchef: v11.0.0 to v11.2.0
- opengist: 1.10.0 to 1.13.1
- libretranslate: v1.6.5 to v1.9.6

Each chart also gets its `version` bumped (so chart-releaser publishes) and a fresh `artifacthub.io/changes` entry. `helm dep up` + `helm lint` pass clean on all four.

## libretranslate persistence fix

While bumping libretranslate I hit a pre-existing `helm lint` failure on `persistence.share`: the `cache`, `db` and `share` volumes carried `cpuPath`/`gpuPath` keys that the bjw-s common library never reads (no template logic ever consumed them) and that broke schema validation. Reworked all persistence entries to the standard `globalMounts` shape, keeping the app's default data paths and dropping the cluster-specific CPU/GPU duality. Rendered output confirms the PVCs and emptyDirs now mount at the right paths.

## Left untouched

- cyberchef image was rebuilt/pushed as v11.2.0 first (confirmed on Docker Hub) before bumping.
- firecrawl stays at 2.10.19: upstream git has v2.11.x tags but the published ghcr image maxes out at 2.10.19, which is already the pinned value.
- Charts tracking `appVersion: latest` (atuin, bolt.diy, draw-things, fooocus, mktxp, ollama) float by design, nothing to pin.
- Already current: dnscrypt-proxy, olvid-bot, technitium-dnsserver, transfer.sh, winbox, nfs-server.
