### PR TITLE
chore: bump chart versions to refresh Artifact Hub, add CloakBrowser icon

### DIFF
--- a/charts/cloakbrowser-mcp/Chart.yaml
+++ b/charts/cloakbrowser-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloakbrowser-mcp
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.6.0"
 kubeVersion: ">=1.31.0-0"
 
@@ -22,6 +22,7 @@ keywords:
   - self-hosted
 
 home: https://github.com/swimmwatch/cloakbrowser-mcp
+icon: https://raw.githubusercontent.com/obeone/charts/main/logo/cloakbrowser-mcp.svg
 sources:
   - https://github.com/swimmwatch/cloakbrowser-mcp
   - https://hub.docker.com/r/swimmwatch/cloakbrowser-mcp
@@ -45,4 +46,6 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to 1.6.0
+      description: Regenerate README from the unified helm-docs template
+    - kind: added
+      description: Chart icon

--- a/charts/cloakbrowser-mcp/README.md
+++ b/charts/cloakbrowser-mcp/README.md
@@ -7,7 +7,7 @@
 -->
 # cloakbrowser-mcp
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cloakbrowser-mcp)
 
 CloakBrowser MCP — a Model Context Protocol browser-automation server that runs upstream @playwright/mcp with the CloakBrowser Chromium binary. This Helm chart packages the bridge in its streamable-http transport so it can be reached over the network, driven entirely from values.yaml via the bjw-s common library.

--- a/charts/cyberchef/Chart.yaml
+++ b/charts/cyberchef/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v11.2.0
 description: GCHQ CyberChef [multi-arch]
 name: cyberchef
-version: 2.0.1
+version: 2.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - cyberchef
@@ -21,4 +21,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to v11.2.0
+      description: Regenerate README from the unified helm-docs template

--- a/charts/cyberchef/README.md
+++ b/charts/cyberchef/README.md
@@ -7,7 +7,7 @@
 -->
 # cyberchef
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: v11.2.0](https://img.shields.io/badge/AppVersion-v11.2.0-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: v11.2.0](https://img.shields.io/badge/AppVersion-v11.2.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cyberchef)
 
 GCHQ CyberChef [multi-arch]

--- a/charts/dnscrypt-proxy/Chart.yaml
+++ b/charts/dnscrypt-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.16
 description: A flexible DNS proxy, with support for encrypted DNS protocols.
 name: dnscrypt-proxy
-version: 1.4.1
+version: 1.4.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - dnscrypt-proxy
@@ -27,4 +27,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion
+      description: Regenerate README from the unified helm-docs template

--- a/charts/dnscrypt-proxy/README.md
+++ b/charts/dnscrypt-proxy/README.md
@@ -7,7 +7,7 @@
 -->
 # dnscrypt-proxy
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 2.1.16](https://img.shields.io/badge/AppVersion-2.1.16-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 2.1.16](https://img.shields.io/badge/AppVersion-2.1.16-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/dnscrypt-proxy)
 
 A flexible DNS proxy, with support for encrypted DNS protocols.

--- a/charts/draw-things/Chart.yaml
+++ b/charts/draw-things/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: draw-things
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 kubeVersion: ">=1.31.0-0"
 
@@ -50,7 +50,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial release packaging the Draw Things gRPC server CLI with NVIDIA GPU support.
-    - kind: added
-      description: Chart icon (Draw Things logo).
+    - kind: changed
+      description: Regenerate README from the unified helm-docs template

--- a/charts/draw-things/README.md
+++ b/charts/draw-things/README.md
@@ -7,7 +7,7 @@
 -->
 # draw-things
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/draw-things)
 
 Draw Things gRPC server — the official CLI image that exposes a gRPC API for Stable Diffusion image generation, intended to be paired with the macOS/iOS Draw Things app for remote inference on a beefier GPU than your phone. This chart packages it with the bjw-s common library so behaviour is driven almost entirely from values.yaml.

--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.1
+version: 2.0.2
 appVersion: "2.10.19"
 kubeVersion: ">=1.25.0-0"
 
@@ -49,7 +49,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial release — rebuilt on the bjw-s common library with the current self-hosted topology (NuQ queue, RabbitMQ, multi-worker split) and official ghcr.io images.
-    - kind: fixed
-      description: First installable release; the 2.0.0 tag was created but never reached the chart index due to a release-pipeline issue, so 2.0.1 supersedes it.
+    - kind: changed
+      description: Regenerate README from the unified helm-docs template

--- a/charts/firecrawl/README.md
+++ b/charts/firecrawl/README.md
@@ -7,7 +7,7 @@
 -->
 # firecrawl
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10.19](https://img.shields.io/badge/AppVersion-2.10.19-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.10.19](https://img.shields.io/badge/AppVersion-2.10.19-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/firecrawl)
 
 Firecrawl is an open-source API that crawls websites and turns them into LLM-ready data (markdown, HTML, structured JSON). This chart packages the self-hosted topology — API, workers, Playwright renderer and the bundled Redis / RabbitMQ / NuQ-Postgres backends — using the bjw-s common library, with official ghcr.io images.

--- a/charts/fooocus/Chart.yaml
+++ b/charts/fooocus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: Fooocus is an image generating software
 name: fooocus
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - fooocus
@@ -23,4 +23,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Corrected type for securityContext and podSecurityContext fields to match the expected types in Kubernetes.
+      description: Regenerate README from the unified helm-docs template

--- a/charts/fooocus/README.md
+++ b/charts/fooocus/README.md
@@ -7,7 +7,7 @@
 -->
 # fooocus
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/fooocus)
 
 Fooocus is an image generating software

--- a/charts/libretranslate/Chart.yaml
+++ b/charts/libretranslate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.6
 description: Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup.
 name: libretranslate
-version: 1.0.5
+version: 1.0.6
 kubeVersion: ">=1.16.0-0"
 keywords:
   - libretranslate
@@ -28,6 +28,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to v1.9.6
-    - kind: fixed
-      description: Fix persistence volumes to use bjw-s common globalMounts
+      description: Regenerate README from the unified helm-docs template

--- a/charts/libretranslate/README.md
+++ b/charts/libretranslate/README.md
@@ -7,7 +7,7 @@
 -->
 # libretranslate
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/libretranslate)
 
 Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup.

--- a/charts/mktxp/Chart.yaml
+++ b/charts/mktxp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: Mikrotik (RouterOS) exporter for Prometheus metics
 name: mktxp
-version: 1.1.9
+version: 1.1.10
 kubeVersion: ">=1.16.0-0"
 keywords:
 - mktxp
@@ -30,9 +30,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Run the pod as uid/gid 1000 (matching the upstream image) and drop the hardcoded chown 100:101 in the init-container that broke writes after upstream switched the user
-    - kind: added
-      description: compact_default_conf_values setting in the default _mktxp.conf so the migration step on first boot does not crash with KeyError
     - kind: changed
-      description: Switch image.pullPolicy default to IfNotPresent so upstream surprises do not silently land at restart. Keep image.tag at `latest` because akpw/mktxp on ghcr.io only publishes :latest and stable-YYYYMMDD tags — there is no semver tag to pin to.
+      description: Regenerate README from the unified helm-docs template

--- a/charts/mktxp/README.md
+++ b/charts/mktxp/README.md
@@ -7,7 +7,7 @@
 -->
 # mktxp
 
-![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/mktxp)
 
 Mikrotik (RouterOS) exporter for Prometheus metics

--- a/charts/nfs-server/Chart.yaml
+++ b/charts/nfs-server/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - file-server
   - file-storage
   - sharing
-version: 1.1.3
+version: 1.1.4
 appVersion: 2.2.2
 
 icon: https://raw.githubusercontent.com/obeone/charts/main/logo/nfs.png
@@ -33,5 +33,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: added
-      description: Value schema
+    - kind: changed
+      description: Regenerate README from the unified helm-docs template

--- a/charts/nfs-server/README.md
+++ b/charts/nfs-server/README.md
@@ -7,7 +7,7 @@
 -->
 # nfs-server
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/nfs-server)
 
 A lightweight, robust, flexible, and containerized NFS server. This charts support multiarch

--- a/charts/ollama/Chart.yaml
+++ b/charts/ollama/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ollama
-version: 0.2.0
+version: 0.2.1
 appVersion: "latest"
 kubeVersion: ">=1.31.0-0"
 
@@ -47,11 +47,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: removed
-      description: Drop cluster-specific Service defaults (dual-stack ipFamilyPolicy/ipFamilies) so the chart ships portable defaults
     - kind: changed
-      description: Stop hard-coding personal tuning constants (context length, keep-alive, parallelism, flash-attention); they are now commented examples and Ollama's own defaults apply
-    - kind: changed
-      description: Collapse the separate metrics Service port into the http port; metrics are scraped on http /metrics via the ServiceMonitor
-    - kind: changed
-      description: Switch liveness/readiness probes from tcpSocket to httpGet on /
+      description: Regenerate README from the unified helm-docs template

--- a/charts/ollama/README.md
+++ b/charts/ollama/README.md
@@ -7,7 +7,7 @@
 -->
 # ollama
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/ollama)
 
 Ollama — run large language models locally, with an optional transparent Prometheus exporter/proxy sidecar you toggle with a single switch (exporter.enabled): on, it fronts the API and exports /metrics; off, the API is served directly. This Helm chart packages the Ollama server on the bjw-s common library so behaviour is driven almost entirely from values.yaml. Supports GPU acceleration via RuntimeClass.

--- a/charts/olvid-bot/Chart.yaml
+++ b/charts/olvid-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: olvid-bot
-version: 0.3.0
+version: 0.3.1
 appVersion: 2.0.1
 kubeVersion: ">=1.22.0-0"
 
@@ -43,4 +43,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update olvid-bot image to v2.0.1
+      description: Regenerate README from the unified helm-docs template

--- a/charts/olvid-bot/README.md
+++ b/charts/olvid-bot/README.md
@@ -7,7 +7,7 @@
 -->
 # olvid-bot
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/olvid-bot)
 
 Olvid bot-daemon — a bridge service that lets you automate interactions with Olvid secure-messaging groups. This Helm chart packages the daemon using the bjw-s common library, so behaviour is driven almost entirely from *values.yaml*.

--- a/charts/opengist/Chart.yaml
+++ b/charts/opengist/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opengist
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.13.1
 kubeVersion: ">=1.16.0-0"
 
@@ -42,4 +42,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to 1.13.1
+      description: Regenerate README from the unified helm-docs template

--- a/charts/opengist/README.md
+++ b/charts/opengist/README.md
@@ -7,7 +7,7 @@
 -->
 # opengist
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.13.1](https://img.shields.io/badge/AppVersion-1.13.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/opengist)
 
 Opengist is a self-hosted Pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface. It is similar to GitHub Gist, but open-source and self-hosted.

--- a/charts/technitium-dnsserver/Chart.yaml
+++ b/charts/technitium-dnsserver/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - pihole
   - adguard
 
-version: 1.11.0
+version: 1.11.1
 appVersion: "15.2.0"
 
 icon: https://raw.githubusercontent.com/obeone/charts/main/logo/technitium-dnsserver.png
@@ -33,4 +33,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: Update appVersion to 15.2.0
+      description: Regenerate README from the unified helm-docs template

--- a/charts/technitium-dnsserver/README.md
+++ b/charts/technitium-dnsserver/README.md
@@ -7,7 +7,7 @@
 -->
 # technitium-dnsserver
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.2.0](https://img.shields.io/badge/AppVersion-15.2.0-informational?style=flat-square)
+![Version: 1.11.1](https://img.shields.io/badge/Version-1.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 15.2.0](https://img.shields.io/badge/AppVersion-15.2.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/technitium-dnsserver)
 
 Technitium DNS Server is a DNS that can be use as a piHole or AdGuardHome replacement. It can also be used as authoritative server

--- a/charts/transfer.sh/Chart.yaml
+++ b/charts/transfer.sh/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: transfer.sh
-version: 1.0.3
+version: 1.0.4
 appVersion: v1.6.1
 description: |
   High-performance, secure and user-friendly command-line file sharing tool.
@@ -37,7 +37,5 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - kind: added
-      description: NOTES.txt
     - kind: changed
-      description: Updated bjw-s library chart to v4.1.2
+      description: Regenerate README from the unified helm-docs template

--- a/charts/transfer.sh/README.md
+++ b/charts/transfer.sh/README.md
@@ -7,7 +7,7 @@
 -->
 # transfer.sh
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: v1.6.1](https://img.shields.io/badge/AppVersion-v1.6.1-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: v1.6.1](https://img.shields.io/badge/AppVersion-v1.6.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/transfer.sh)
 
 High-performance, secure and user-friendly command-line file sharing tool.

--- a/logo/cloakbrowser-mcp.svg
+++ b/logo/cloakbrowser-mcp.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="CloakBrowser MCP">
+  <defs>
+    <linearGradient id="frame" x1="20" y1="14" x2="108" y2="114" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#14b8a6" />
+      <stop offset="0.58" stop-color="#0f766e" />
+      <stop offset="1" stop-color="#f97316" />
+    </linearGradient>
+    <linearGradient id="glass" x1="34" y1="32" x2="96" y2="94" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#cbd5e1" />
+    </linearGradient>
+    <filter id="shadow" x="8" y="8" width="112" height="112" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#020617" flood-opacity="0.32" />
+    </filter>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="#0f172a" />
+  <path d="M23 34a14 14 0 0 1 14-14h54a14 14 0 0 1 14 14v60a14 14 0 0 1-14 14H37a14 14 0 0 1-14-14V34Z" fill="url(#frame)" filter="url(#shadow)" />
+  <path d="M34 41a9 9 0 0 1 9-9h42a9 9 0 0 1 9 9v48a9 9 0 0 1-9 9H43a9 9 0 0 1-9-9V41Z" fill="#0f172a" />
+  <path d="M34 42a10 10 0 0 1 10-10h40a10 10 0 0 1 10 10v7H34v-7Z" fill="#1e293b" />
+  <circle cx="44" cy="40" r="3" fill="#f97316" />
+  <circle cx="55" cy="40" r="3" fill="#fbbf24" />
+  <circle cx="66" cy="40" r="3" fill="#14b8a6" />
+  <path d="M64 53c14 0 25 8 29 21-7 3-12 10-12 18 0 4 1 8 3 11-5 3-12 5-20 5s-15-2-20-5c2-3 3-7 3-11 0-8-5-15-12-18 4-13 15-21 29-21Z" fill="#14b8a6" />
+  <path d="M47 75c5-6 11-9 17-9s12 3 17 9c-4 8-10 12-17 12s-13-4-17-12Z" fill="url(#glass)" />
+  <circle cx="64" cy="76" r="8" fill="#0f172a" />
+  <circle cx="67" cy="73" r="2.5" fill="#f8fafc" />
+  <path d="M89 91h13m-6-6v12M28 91h13m-6-6v12" stroke="#f97316" stroke-width="5" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
Follow-up to #37. The unified README template only reaches Artifact Hub when each chart publishes a new version (chart-releaser republishes on version change only), so this bumps a patch on the charts to force the refresh.

## Changes

- Patch version bump on 14 charts, with the artifacthub.io/changes annotation updated to note the README regeneration.
- READMEs regenerated so the version badge matches.
- New icon for cloakbrowser-mcp: the upstream brand logo (docs/assets/brand/logo.svg), stored under logo/ like the other charts.

## Notes

- winbox is intentionally left untouched (stays at 1.3.9).
- fooocus keeps no icon on purpose: lllyasviel ships no logo for it, and none exists on dashboard-icons or selfh.st either. Rather than fabricate a brand mark, it keeps the default Artifact Hub placeholder.
- No dependency changes, so no helm dep up needed. helm lint passes on every touched chart.
- The two untracked WIP charts (bolt.diy, wallabag) are out of scope and still need icons when they land.