### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.10
-appVersion: "2.11.146"
+version: 2.0.11
+appVersion: "2.11.150"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -50,4 +50,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: "2026-07-28: Update Firecrawl to 2.11.146"
+      description: "2026-07-29: Update Firecrawl to 2.11.150"


### PR DESCRIPTION
## Updated charts

| Chart | appVersion | Chart version |
| --- | --- | --- |
| firecrawl | 2.11.146 -> 2.11.150 | 2.0.10 -> 2.0.11 |

Upstream tag `ghcr.io/firecrawl/firecrawl:2.11.150` verified present on the registry before the bump.
`helm lint charts/firecrawl` passes with no errors or warnings.

No charts skipped.

Changelog: https://github.com/firecrawl/firecrawl/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)