### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.11
-appVersion: "2.11.150"
+version: 2.0.12
+appVersion: "2.11.152"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -50,4 +50,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: "2026-07-29: Update Firecrawl to 2.11.150"
+      description: "2026-07-29: Update Firecrawl to 2.11.152"


### PR DESCRIPTION
Automated chart update routine.

Updated charts:

- firecrawl: 2.11.150 -> 2.11.152 (chart 2.0.11 -> 2.0.12)

No charts were skipped. `helm lint charts/firecrawl` passes and the `ghcr.io/firecrawl/firecrawl:2.11.152` manifest was verified to exist before the bump.

Generated with Claude Code.