### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.12
-appVersion: "2.11.152"
+version: 2.0.13
+appVersion: "2.11.158"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -50,4 +50,4 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/changes: |
     - kind: changed
-      description: "2026-07-29: Update Firecrawl to 2.11.152"
+      description: "2026-07-30: Update Firecrawl to 2.11.158"


### PR DESCRIPTION
Automated chart maintenance run (charts-checker).

## Updated

| Chart | Chart version | App version |
| --- | --- | --- |
| firecrawl | 2.0.12 -> 2.0.13 | 2.11.152 -> 2.11.158 |

The `ghcr.io/firecrawl/firecrawl:2.11.158` manifest was confirmed present on the registry before the bump. `helm dep up` and `helm lint charts/firecrawl` both ran clean (0 failures, no warnings). All Firecrawl component images in `values.yaml` resolve their tag from `.Chart.AppVersion`, so nothing else needed touching.

## Skipped

None. Firecrawl was the only chart with an available update this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)