### PR TITLE
feat: add disabled Gateway API HTTPRoute examples to bjw-s charts

### DIFF
--- a/charts/cloakbrowser-mcp/Chart.yaml
+++ b/charts/cloakbrowser-mcp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloakbrowser-mcp
-version: 0.2.2
+version: 0.2.3
 appVersion: "1.10.0"
 kubeVersion: ">=1.31.0-0"
 
@@ -45,5 +45,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update CloakBrowser MCP to 1.10.0
+    - kind: added
+      description: Add a disabled Gateway API HTTPRoute example mirroring the Ingress

--- a/charts/cloakbrowser-mcp/README.md
+++ b/charts/cloakbrowser-mcp/README.md
@@ -7,7 +7,7 @@
 -->
 # cloakbrowser-mcp
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cloakbrowser-mcp)
 
 CloakBrowser MCP — a Model Context Protocol browser-automation server that runs upstream @playwright/mcp with the CloakBrowser Chromium binary. This Helm chart packages the bridge in its streamable-http transport so it can be reached over the network, driven entirely from values.yaml via the bjw-s common library.
@@ -120,6 +120,12 @@ Kubernetes: `>=1.31.0-0`
 | defaultPodOptions | object | `{"automountServiceAccountToken":false,"securityContext":{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}}` | Pod-wide options applied to every controller in this chart. |
 | ingress | object | `{"main":{"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix","service":{"identifier":"main","port":"http"}}]}],"tls":[{"hosts":["chart-example.local"],"secretName":"tls-chart-example-local"}]}}` | Ingress. Disabled by default; flip enabled and set a real host to expose the MCP endpoint. The bridge speaks plain HTTP, so terminate TLS at the ingress. |
 | persistence | object | `{"data":{"globalMounts":[{"path":"/data"}],"type":"emptyDir"},"dshm":{"globalMounts":[{"path":"/dev/shm"}],"medium":"Memory","sizeLimit":"1Gi","type":"emptyDir"}}` | Storage. Artifacts under /data are transient by default (emptyDir). Switch the "data" volume to a persistentVolumeClaim if you need to keep them across restarts. |
+| route | object | `{"main":{"enabled":false,"hostnames":["chart-example.local"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"backendRefs":[{"identifier":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default: pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and an existing Gateway in the cluster. |
+| route.main.enabled | bool | `false` | Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`. |
+| route.main.hostnames | list | `["chart-example.local"]` | Hostnames served by this route. |
+| route.main.kind | string | `"HTTPRoute"` | Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute. |
+| route.main.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Gateways this route attaches to. |
+| route.main.rules | list | `[{"backendRefs":[{"identifier":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules. `identifier` refers to a Service defined above. |
 | service | object | `{"main":{"controller":"main","ports":{"http":{"port":3000,"protocol":"TCP","targetPort":3000}},"type":"ClusterIP"}}` | Service exposing the streamable-http MCP endpoint inside the cluster. |
 
 ## Verifying the chart signature

--- a/charts/cloakbrowser-mcp/values.yaml
+++ b/charts/cloakbrowser-mcp/values.yaml
@@ -154,6 +154,33 @@ ingress:
           - chart-example.local
         secretName: tls-chart-example-local
 
+# -- Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default:
+# pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and
+# an existing Gateway in the cluster.
+route:
+  main:
+    # -- Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`.
+    enabled: false
+    # -- Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute.
+    kind: HTTPRoute
+    # -- Gateways this route attaches to.
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        # -- Listener name on the Gateway. Optional.
+        # sectionName: https
+    # -- Hostnames served by this route.
+    hostnames:
+      - chart-example.local
+    # -- Routing rules. `identifier` refers to a Service defined above.
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          - identifier: main
+
 # -- Storage. Artifacts under /data are transient by default (emptyDir). Switch the
 # "data" volume to a persistentVolumeClaim if you need to keep them across restarts.
 persistence:

--- a/charts/draw-things/Chart.yaml
+++ b/charts/draw-things/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: draw-things
-version: 0.1.2
+version: 0.1.3
 appVersion: latest
 kubeVersion: ">=1.31.0-0"
 
@@ -50,5 +50,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: changed
-      description: Regenerate README from the unified helm-docs template
+    - kind: added
+      description: Add a disabled Gateway API HTTPRoute example mirroring the Ingress

--- a/charts/draw-things/README.md
+++ b/charts/draw-things/README.md
@@ -7,7 +7,7 @@
 -->
 # draw-things
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/draw-things)
 
 Draw Things gRPC server — the official CLI image that exposes a gRPC API for Stable Diffusion image generation, intended to be paired with the macOS/iOS Draw Things app for remote inference on a beefier GPU than your phone. This chart packages it with the bjw-s common library so behaviour is driven almost entirely from values.yaml.
@@ -111,6 +111,12 @@ Kubernetes: `>=1.31.0-0`
 | persistence.models.globalMounts[0].path | string | `"/grpc-models"` |  |
 | persistence.models.size | string | `"50Gi"` |  |
 | persistence.models.type | string | `"persistentVolumeClaim"` |  |
+| route | object | `{"main":{"enabled":false,"hostnames":["draw-things.local"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"backendRefs":[{"identifier":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default: pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and an existing Gateway in the cluster. Same gRPC (h2c) caveat as the Ingress applies. |
+| route.main.enabled | bool | `false` | Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`. |
+| route.main.hostnames | list | `["draw-things.local"]` | Hostnames served by this route. |
+| route.main.kind | string | `"HTTPRoute"` | Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute. |
+| route.main.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Gateways this route attaches to. |
+| route.main.rules | list | `[{"backendRefs":[{"identifier":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules. `identifier` refers to a Service defined above. |
 | service.main.controller | string | `"main"` |  |
 | service.main.ports.grpc.port | int | `7859` |  |
 | service.main.ports.grpc.protocol | string | `"TCP"` |  |

--- a/charts/draw-things/values.yaml
+++ b/charts/draw-things/values.yaml
@@ -78,3 +78,30 @@ ingress:
       - hosts:
           - draw-things.local
         secretName: draw-things-tls
+
+# -- Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default:
+# pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and
+# an existing Gateway in the cluster. Same gRPC (h2c) caveat as the Ingress applies.
+route:
+  main:
+    # -- Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`.
+    enabled: false
+    # -- Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute.
+    kind: HTTPRoute
+    # -- Gateways this route attaches to.
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        # -- Listener name on the Gateway. Optional.
+        # sectionName: https
+    # -- Hostnames served by this route.
+    hostnames:
+      - draw-things.local
+    # -- Routing rules. `identifier` refers to a Service defined above.
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          - identifier: main

--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.14
+version: 2.0.15
 appVersion: "2.11.159"
 kubeVersion: ">=1.25.0-0"
 
@@ -49,5 +49,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: changed
-      description: "2026-07-30: Update Firecrawl to 2.11.159"
+    - kind: added
+      description: "2026-07-30: Add a disabled route (HTTPRoute / Gateway API) example, mirroring the existing ingress"

--- a/charts/firecrawl/README.md
+++ b/charts/firecrawl/README.md
@@ -7,7 +7,7 @@
 -->
 # firecrawl
 
-![Version: 2.0.14](https://img.shields.io/badge/Version-2.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.11.159](https://img.shields.io/badge/AppVersion-2.11.159-informational?style=flat-square)
+![Version: 2.0.15](https://img.shields.io/badge/Version-2.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.11.159](https://img.shields.io/badge/AppVersion-2.11.159-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/firecrawl)
 
 Firecrawl is an open-source API that crawls websites and turns them into LLM-ready data (markdown, HTML, structured JSON). This chart packages the self-hosted topology — API, workers, Playwright renderer and the bundled Redis / RabbitMQ / NuQ-Postgres backends — using the bjw-s common library, with official ghcr.io images.
@@ -139,6 +139,8 @@ Kubernetes: `>=1.25.0-0`
 | rabbitmq | object | `{"auth":{"password":"firecrawl","username":"firecrawl"}}` | --------------------------------------------------------------------------- Interpolated into NUQ_RABBITMQ_URL, so these end up visible in plaintext in the rendered manifest (`helm get manifest` / `kubectl get pod -o yaml`). For real secrecy, use an external broker via `firecrawl.rabbitmq.url`. |
 | rabbitmq.auth.password | string | `"firecrawl"` | Set a strong password before deploying to anything reachable. |
 | rabbitmq.auth.username | string | `"firecrawl"` | RabbitMQ username; must NOT be `guest` (RabbitMQ rejects `guest` over non-loopback connections), hence a named user. |
+| route | object | `{"api":{"enabled":false,"hostnames":["firecrawl.example.com"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system","sectionName":"http"}],"rules":[{"backendRefs":[{"identifier":"api","port":"http"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | --------------------------------------------------------------------------- |
+| route.api.enabled | bool | `false` | Expose the API via an HTTPRoute (Gateway API). See the ingress security note above before enabling. |
 | secrets | object | `{"secrets":{"enabled":true,"stringData":{"BULL_AUTH_KEY":"CHANGEME","LLAMAPARSE_API_KEY":"","OPENAI_API_KEY":"","PROXY_PASSWORD":"","SELF_HOSTED_WEBHOOK_HMAC_SECRET":"","SLACK_WEBHOOK_URL":"","TEST_API_KEY":""}}}` | --------------------------------------------------------------------------- To manage these outside the chart, set `enabled: false` and create a Secret named `<release-fullname>-secrets` (the `secret: secrets` reference is fullname-prefixed by the common library) with the same keys. That Secret is also mounted into the Playwright container (for PROXY_PASSWORD), not only the Firecrawl workers. |
 | secrets.secrets.stringData.BULL_AUTH_KEY | string | `"CHANGEME"` | Protects the admin queue dashboard at /admin/<key>/queues (the URL embeds this key verbatim; the dashboard shows the legacy BullMQ queues). The API itself is unauthenticated — this only guards /admin. CHANGE THIS on any deployment reachable from untrusted networks. |
 | secrets.secrets.stringData.LLAMAPARSE_API_KEY | string | `""` | LlamaParse key for PDF parsing. |

--- a/charts/firecrawl/values.yaml
+++ b/charts/firecrawl/values.yaml
@@ -818,3 +818,28 @@ ingress:
     #   - hosts:
     #       - firecrawl.example.com
     #     secretName: tls-firecrawl-example-com
+
+# -----------------------------------------------------------------------------
+# HTTPRoute (API only) — Gateway API alternative to the Ingress above,
+# mutually exclusive with it. Disabled by default.
+# -----------------------------------------------------------------------------
+route:
+  api:
+    # -- Expose the API via an HTTPRoute (Gateway API). See the ingress
+    # security note above before enabling.
+    enabled: false
+    kind: HTTPRoute
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        sectionName: http
+    hostnames:
+      - firecrawl.example.com
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          - identifier: api
+            port: http

--- a/charts/libretranslate/Chart.yaml
+++ b/charts/libretranslate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.6
 description: Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup.
 name: libretranslate
-version: 1.0.6
+version: 1.0.7
 kubeVersion: ">=1.16.0-0"
 keywords:
   - libretranslate
@@ -29,3 +29,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Regenerate README from the unified helm-docs template
+    - kind: added
+      description: Add a disabled Gateway API HTTPRoute example mirroring the Ingress

--- a/charts/libretranslate/README.md
+++ b/charts/libretranslate/README.md
@@ -7,7 +7,7 @@
 -->
 # libretranslate
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
+![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/libretranslate)
 
 Free and Open Source Machine Translation API. Self-hosted, offline capable and easy to setup.
@@ -115,6 +115,12 @@ Kubernetes: `>=1.16.0-0`
 | persistence.db.enabled | bool | `false` | Enable database storage for application data |
 | persistence.files-translate.enabled | bool | `true` | Temporary storage for uploaded translation files |
 | persistence.share.enabled | bool | `true` | Enable persistent shared storage for translation models and shared assets |
+| route | object | `{"main":{"enabled":false,"hostnames":["chart-example.local"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"backendRefs":[{"name":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default: pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and an existing Gateway in the cluster. |
+| route.main.enabled | bool | `false` | Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`. |
+| route.main.hostnames | list | `["chart-example.local"]` | Hostnames served by this route. |
+| route.main.kind | string | `"HTTPRoute"` | Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute. |
+| route.main.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Gateways this route attaches to. `namespace` is required on common 3.x. |
+| route.main.rules | list | `[{"backendRefs":[{"name":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules. `name` resolves to a Service identifier defined above. |
 | service | object | `{"main":{"controller":"main","ports":{"http":{"port":80,"protocol":"TCP","targetPort":5000}}}}` | Service configuration to expose the application internally in the cluster |
 | service.main.ports.http.port | int | `80` | External service port |
 | service.main.ports.http.protocol | string | `"TCP"` | Protocol to use (TCP/UDP) |

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -85,6 +85,33 @@ ingress:
         # -- Secret containing TLS certificate for the ingress
         secretName: tls-chart-example-local
 
+# -- Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default:
+# pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and
+# an existing Gateway in the cluster.
+route:
+  main:
+    # -- Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`.
+    enabled: false
+    # -- Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute.
+    kind: HTTPRoute
+    # -- Gateways this route attaches to. `namespace` is required on common 3.x.
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        # -- Listener name on the Gateway. Optional.
+        # sectionName: https
+    # -- Hostnames served by this route.
+    hostnames:
+      - chart-example.local
+    # -- Routing rules. `name` resolves to a Service identifier defined above.
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          - name: main
+
 # -- Persistence volumes configuration for different data types
 persistence:
   api-keys:

--- a/charts/ollama/Chart.yaml
+++ b/charts/ollama/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ollama
-version: 0.3.0
+version: 0.3.1
 appVersion: "latest"
 kubeVersion: ">=1.31.0-0"
 
@@ -47,9 +47,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: changed
-      description: Harden the exporter/proxy sidecar defaults (100m/128Mi requests, 500m/512Mi limits) so the in-data-path proxy no longer starves and OOMKills under streaming load
-    - kind: changed
-      description: Exporter readiness now probes GET /api/version through the proxy (real Ollama pass-through) instead of /metrics, so the pod is Ready only when the whole exporter->Ollama chain answers
     - kind: added
-      description: Startup probe on the exporter sidecar to give slow cold starts grace before liveness applies
+      description: Add a disabled Gateway API HTTPRoute example mirroring the Ingress

--- a/charts/ollama/README.md
+++ b/charts/ollama/README.md
@@ -7,7 +7,7 @@
 -->
 # ollama
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/ollama)
 
 Ollama — run large language models locally, with an optional transparent Prometheus exporter/proxy sidecar you toggle with a single switch (exporter.enabled): on, it fronts the API and exports /metrics; off, the API is served directly. This Helm chart packages the Ollama server on the bjw-s common library so behaviour is driven almost entirely from values.yaml. Supports GPU acceleration via RuntimeClass.
@@ -161,6 +161,12 @@ Kubernetes: `>=1.31.0-0`
 | persistence.tmp.advancedMounts.main.ollama[0].path | string | `"/tmp/ollama"` |  |
 | persistence.tmp.enabled | bool | `true` |  |
 | persistence.tmp.type | string | `"emptyDir"` |  |
+| route | object | `{"main":{"enabled":false,"hostnames":["chart-example.local"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"backendRefs":[{"identifier":"main","port":"http"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default: pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and an existing Gateway in the cluster. |
+| route.main.enabled | bool | `false` | Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`. |
+| route.main.hostnames | list | `["chart-example.local"]` | Hostnames served by this route. |
+| route.main.kind | string | `"HTTPRoute"` | Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute. |
+| route.main.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Gateways this route attaches to. |
+| route.main.rules | list | `[{"backendRefs":[{"identifier":"main","port":"http"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules. `identifier` refers to a Service defined above. |
 | service.main.controller | string | `"main"` |  |
 | service.main.ports.http.port | int | `11434` |  |
 | service.main.ports.http.primary | bool | `true` |  |

--- a/charts/ollama/values.yaml
+++ b/charts/ollama/values.yaml
@@ -208,6 +208,36 @@ ingress:
       #   hosts:
       #     - chart-example.local
 
+# -- Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default:
+# pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and
+# an existing Gateway in the cluster.
+route:
+  main:
+    # -- Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`.
+    enabled: false
+    # -- Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute.
+    kind: HTTPRoute
+    # -- Gateways this route attaches to.
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        # -- Listener name on the Gateway. Optional.
+        # sectionName: https
+    # -- Hostnames served by this route.
+    hostnames:
+      - chart-example.local
+    # -- Routing rules. `identifier` refers to a Service defined above.
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          - identifier: main
+            # Route to the proxied API port (11434 -> exporter :8000 -> Ollama),
+            # not the raw /metrics scrape port, same as the Ingress above.
+            port: http
+
 persistence:
   # Ollama model/blob store. Mounted only into the ollama container.
   data:

--- a/charts/olvid-bot/Chart.yaml
+++ b/charts/olvid-bot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: olvid-bot
-version: 0.3.2
+version: 0.3.3
 appVersion: 2.0.1
 kubeVersion: ">=1.22.0-0"
 
@@ -42,5 +42,5 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Switch chart icon from WebP to PNG so Artifact Hub can decode the logo
+    - kind: added
+      description: Add a disabled route (HTTPRoute / Gateway API) example, mirroring the existing ingress

--- a/charts/olvid-bot/README.md
+++ b/charts/olvid-bot/README.md
@@ -7,7 +7,7 @@
 -->
 # olvid-bot
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/olvid-bot)
 
 Olvid bot-daemon — a bridge service that lets you automate interactions with Olvid secure-messaging groups. This Helm chart packages the daemon using the bjw-s common library, so behaviour is driven almost entirely from *values.yaml*.
@@ -102,6 +102,8 @@ Kubernetes: `>=1.22.0-0`
 | persistence.data.globalMounts[0].path | string | `"/daemon/data"` |  |
 | persistence.data.size | string | `"1Gi"` |  |
 | persistence.data.type | string | `"persistentVolumeClaim"` |  |
+| route | object | `{"main":{"enabled":false,"hostnames":["chart-example.local"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system","sectionName":"http"}],"rules":[{"backendRefs":[{"identifier":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | Gateway API alternative to the Ingress above, mutually exclusive with it. Disabled by default. |
+| route.main.rules[0].backendRefs[0] | object | `{"identifier":"main"}` | No `port` set: common 4.1.2's route template does not resolve port names (unlike Ingress), so this defaults to the service's primary port instead of emitting an invalid literal. |
 | secrets | object | `{"admin-credentials":{"enabled":true,"stringData":{"OLVID_ADMIN_CLIENT_KEY_CLI":"eb9uyjbcuiFhmjFCVKdM"}}}` | --------------------------------------------------------------------------- IMPORTANT:   - Replace the placeholder value with a strong random string before deploying.   - If you prefer managing the Secret outside the chart, set `enabled: false`     and ensure a Secret with the same name exists in the namespace. |
 | service.main.controller | string | `"main"` |  |
 | service.main.ports.grpc.port | int | `50051` |  |

--- a/charts/olvid-bot/values.yaml
+++ b/charts/olvid-bot/values.yaml
@@ -68,3 +68,26 @@ ingress:
       - hosts:
           - chart-example.local
         secretName: tls-chart-example-local
+
+# -- Gateway API alternative to the Ingress above, mutually exclusive with
+# it. Disabled by default.
+route:
+  main:
+    enabled: false
+    kind: HTTPRoute
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        sectionName: http
+    hostnames:
+      - chart-example.local
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          # -- No `port` set: common 4.1.2's route template does not resolve
+          # port names (unlike Ingress), so this defaults to the service's
+          # primary port instead of emitting an invalid literal.
+          - identifier: main

--- a/charts/opengist/Chart.yaml
+++ b/charts/opengist/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opengist
-version: 1.1.4
+version: 1.1.5
 appVersion: 1.15.0
 kubeVersion: ">=1.16.0-0"
 
@@ -43,3 +43,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Update Opengist to 1.15.0
+    - kind: added
+      description: Add a disabled Gateway API HTTPRoute example mirroring the Ingress

--- a/charts/opengist/README.md
+++ b/charts/opengist/README.md
@@ -7,7 +7,7 @@
 -->
 # opengist
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 1.15.0](https://img.shields.io/badge/AppVersion-1.15.0-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![AppVersion: 1.15.0](https://img.shields.io/badge/AppVersion-1.15.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/opengist)
 
 Opengist is a self-hosted Pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface. It is similar to GitHub Gist, but open-source and self-hosted.
@@ -101,6 +101,14 @@ Kubernetes: `>=1.16.0-0`
 | ingress.main.tls[0].hosts[0] | string | `"gist.example.com"` |  |
 | ingress.main.tls[0].secretName | string | `"gist-tls-cert"` |  |
 | persistence | string | `nil` |  |
+| route.main.enabled | bool | `false` |  |
+| route.main.hostnames[0] | string | `"gist.example.com"` |  |
+| route.main.kind | string | `"HTTPRoute"` |  |
+| route.main.parentRefs[0].name | string | `"gateway"` |  |
+| route.main.parentRefs[0].namespace | string | `"gateway-system"` |  |
+| route.main.rules[0].backendRefs[0].name | string | `"main"` |  |
+| route.main.rules[0].matches[0].path.type | string | `"PathPrefix"` |  |
+| route.main.rules[0].matches[0].path.value | string | `"/"` |  |
 | service.main.controller | string | `"main"` |  |
 | service.main.ports.http.port | int | `80` |  |
 | service.main.ports.http.protocol | string | `"TCP"` |  |

--- a/charts/opengist/values.yaml
+++ b/charts/opengist/values.yaml
@@ -166,6 +166,34 @@ ingress:
         # Kubernetes Secret that holds the TLS certificate and key.
         secretName: gist-tls-cert
 
+# Gateway API HTTPRoute, mirroring the Ingress above. Disabled by default:
+# pick either Ingress or HTTPRoute, not both. Requires the Gateway API CRDs and
+# an existing Gateway in the cluster.
+route:
+  main:
+    # Enable the HTTPRoute. Mutually exclusive with `ingress.main.enabled`.
+    enabled: false
+    # Route kind. HTTPRoute, GRPCRoute, TCPRoute, TLSRoute or UDPRoute.
+    kind: HTTPRoute
+    # Gateways this route attaches to. `namespace` is required on common 3.x.
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        # Listener name on the Gateway. Optional.
+        # sectionName: https
+    # Hostnames served by this route.
+    hostnames:
+      - gist.example.com
+    # Routing rules. `name` resolves to a Service identifier defined above.
+    rules:
+      - matches:
+          - path:
+              # Path matching strategy.
+              type: PathPrefix
+              value: /
+        backendRefs:
+          - name: main
+
 # Define persistence (storage) for OpenGist.
 persistence:
 

--- a/charts/transfer.sh/Chart.yaml
+++ b/charts/transfer.sh/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: transfer.sh
-version: 1.0.4
+version: 1.0.5
 appVersion: v1.6.1
 description: |
   High-performance, secure and user-friendly command-line file sharing tool.
@@ -37,5 +37,5 @@ annotations:
       email: obeone@obeone.org
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - kind: changed
-      description: Regenerate README from the unified helm-docs template
+    - kind: added
+      description: Add a disabled route (HTTPRoute / Gateway API) example, mirroring the existing ingress

--- a/charts/transfer.sh/README.md
+++ b/charts/transfer.sh/README.md
@@ -7,7 +7,7 @@
 -->
 # transfer.sh
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: v1.6.1](https://img.shields.io/badge/AppVersion-v1.6.1-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: v1.6.1](https://img.shields.io/badge/AppVersion-v1.6.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/transfer.sh)
 
 High-performance, secure and user-friendly command-line file sharing tool.
@@ -94,6 +94,8 @@ Kubernetes: `>=1.16.0-0`
 | controllers.main.strategy | string | `"Recreate"` |  |
 | ingress.main | object | `{"enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"path":"/","pathType":"Prefix","service":{"identifier":"main","port":"http"}}]}],"tls":[{"hosts":["chart-example.local"],"secretName":"tls-chart-example-local"}]}` | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | `{"storage":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"globalMounts":[{"path":"/storage"}],"size":"10Gi"}}` | Configure persistence settings for the chart under this key. |
+| route | object | `{"main":{"enabled":false,"hostnames":["chart-example.local"],"kind":"HTTPRoute","parentRefs":[{"name":"gateway","namespace":"gateway-system","sectionName":"http"}],"rules":[{"backendRefs":[{"identifier":"main"}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}}` | Gateway API alternative to the Ingress above, mutually exclusive with it. Disabled by default. |
+| route.main.rules[0].backendRefs[0] | object | `{"identifier":"main"}` | No `port` set: common 4.1.2's route template does not resolve port names (unlike Ingress), so this defaults to the service's primary port instead of emitting an invalid literal. |
 | service | object | `{"main":{"controller":"main","ports":{"http":{"port":80,"protocol":"TCP","targetPort":8080}}}}` | Configures service settings for the chart. |
 
 ## Verifying the chart signature

--- a/charts/transfer.sh/values.yaml
+++ b/charts/transfer.sh/values.yaml
@@ -59,6 +59,29 @@ ingress:
           - chart-example.local
         secretName: tls-chart-example-local
 
+# -- Gateway API alternative to the Ingress above, mutually exclusive with
+# it. Disabled by default.
+route:
+  main:
+    enabled: false
+    kind: HTTPRoute
+    parentRefs:
+      - name: gateway
+        namespace: gateway-system
+        sectionName: http
+    hostnames:
+      - chart-example.local
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        backendRefs:
+          # -- No `port` set: common 4.1.2's route template does not resolve
+          # port names (unlike Ingress), so this defaults to the service's
+          # primary port instead of emitting an invalid literal.
+          - identifier: main
+
 # -- Configure persistence settings for the chart under this key.
 persistence:
   storage:


### PR DESCRIPTION
## Summary

Every chart built on the bjw-s common library now ships a `route:` block that mirrors its existing `ingress:` block, disabled by default. It is documentation more than configuration: someone running Gateway API instead of an Ingress controller gets a working starting point in the values file rather than having to reverse-engineer the library's schema.

Eight charts are covered: cloakbrowser-mcp, draw-things, ollama, firecrawl, olvid-bot, transfer.sh, libretranslate and opengist. Each block reuses the same placeholder hostnames, paths and backend service as the ingress it mirrors, so the two stay readable side by side.

Nothing changes for existing users. Every `route.<id>.enabled` defaults to `false`, and no other value was touched.

## Version-specific gotchas

Three lineages of the common library coexist here and they do not share the same route schema. Getting this wrong renders a broken manifest rather than failing loudly, so it is worth recording:

- On common 3.7.x (libretranslate, opengist), `backendRefs[].name` is resolved through the Service identifier lookup and `parentRefs[].namespace` is mandatory. There is no `identifier` key at that version.
- From 4.x onwards (everything else), `name` is taken as a literal Kubernetes object name and `identifier` is what resolves a Service declared in the chart.
- Common 4.1.2 specifically (olvid-bot, transfer.sh) emits `backendRefs[].port` verbatim, with no name-to-number resolution. Passing `port: http` there would produce a non-numeric port in the HTTPRoute, so those two omit the key entirely and fall back to the Service primary port.

No `values.schema.json` needed updating: they are all bare `$ref`s to the upstream common schema, which already declares `route`.

## Test plan

- `helm lint` passes on all eight charts.
- `helm template --set route.<id>.enabled=true` renders a valid HTTPRoute on each, with the backend resolving to the expected Service and port.
- READMEs regenerated with helm-docs from the repository root, so the values tables include the new keys.
- Chart versions bumped with a matching `artifacthub.io/changes` entry, as chart-releaser only publishes new versions.
