### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ helm install my-release obeone/<chart> --verify
 | 🔪 | [**cyberchef**](charts/cyberchef) | `v11.2.0` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
 | 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.16` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
 | 🖌️ | [**draw-things**](charts/draw-things) | `latest` | [Draw Things](https://drawthings.ai) gRPC server — Stable Diffusion inference backend for the macOS/iOS app, GPU-accelerated. |
-| 🔥 | [**firecrawl**](charts/firecrawl) | `2.10.19` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
+| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.162` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
 | 🎨 | [**fooocus**](charts/fooocus) | `latest` | [Fooocus](https://github.com/lllyasviel/Fooocus) — open-source image-generation UI on top of Stable Diffusion. |
 | 🌍 | [**libretranslate**](charts/libretranslate) | `v1.9.6` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
 | 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |

--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.15
-appVersion: "2.11.159"
+version: 2.0.16
+appVersion: "2.11.162"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -51,3 +51,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "2026-07-30: Add a disabled route (HTTPRoute / Gateway API) example, mirroring the existing ingress"
+    - kind: changed
+      description: "2026-07-31: Bump appVersion to 2.11.162"


### PR DESCRIPTION
## Summary

- firecrawl: 2.11.159 -> 2.11.162

Generated automatically by the chart-watch routine.