### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ helm install my-release obeone/<chart> --verify
 | 🔪 | [**cyberchef**](charts/cyberchef) | `v11.2.0` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
 | 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.16` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
 | 🖌️ | [**draw-things**](charts/draw-things) | `latest` | [Draw Things](https://drawthings.ai) gRPC server — Stable Diffusion inference backend for the macOS/iOS app, GPU-accelerated. |
-| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.167` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
+| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.170` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
 | 🎨 | [**fooocus**](charts/fooocus) | `latest` | [Fooocus](https://github.com/lllyasviel/Fooocus) — open-source image-generation UI on top of Stable Diffusion. |
 | 🌍 | [**libretranslate**](charts/libretranslate) | `v1.9.6` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
 | 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |

--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.17
-appVersion: "2.11.167"
+version: 2.0.18
+appVersion: "2.11.170"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -55,3 +55,5 @@ annotations:
       description: "2026-07-31: Bump appVersion to 2.11.162"
     - kind: changed
       description: "2026-08-01: Bump appVersion to 2.11.167"
+    - kind: changed
+      description: "2026-08-03: Bump appVersion to 2.11.170"


### PR DESCRIPTION
## Summary

Bumps the following chart to the latest upstream release:

- firecrawl: 2.11.167 -> 2.11.170