### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ helm install my-release obeone/<chart> --verify
 | | Chart | App | Description |
 | :-: | --- | --- | --- |
 | 🕵️ | [**cloakbrowser-mcp**](charts/cloakbrowser-mcp) | `1.8.0` | [CloakBrowser MCP](https://github.com/swimmwatch/cloakbrowser-mcp) — Playwright browser-automation MCP server over HTTP, backed by a stealth Chromium. |
-| 🔪 | [**cyberchef**](charts/cyberchef) | `v11.2.0` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
+| 🔪 | [**cyberchef**](charts/cyberchef) | `v11.3.0` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
 | 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.16` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
 | 🖌️ | [**draw-things**](charts/draw-things) | `latest` | [Draw Things](https://drawthings.ai) gRPC server — Stable Diffusion inference backend for the macOS/iOS app, GPU-accelerated. |
-| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.170` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
+| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.174` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
 | 🎨 | [**fooocus**](charts/fooocus) | `latest` | [Fooocus](https://github.com/lllyasviel/Fooocus) — open-source image-generation UI on top of Stable Diffusion. |
 | 🌍 | [**libretranslate**](charts/libretranslate) | `v1.9.6` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
 | 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |
 | 📂 | [**nfs-server**](charts/nfs-server) | `2.2.2` | Lightweight, multi-arch [containerized NFS server](https://github.com/obeone/docker-nfs-server). |
 | 🦙 | [**ollama**](charts/ollama) | `latest` | [Ollama](https://ollama.com) — run LLMs locally, with an optional single-switch transparent Prometheus exporter/proxy sidecar (cosign-signed). GPU-accelerated, multi-arch. |
 | 💬 | [**olvid-bot**](charts/olvid-bot) | `2.0.1` | [Olvid bot-daemon](https://gitlab.com/olvid/olvid) — bridge to automate Olvid secure-messaging groups. |
-| 📝 | [**opengist**](charts/opengist) | `1.13.1` | [Opengist](https://github.com/thomiceli/opengist) — self-hosted, Git-backed Pastebin / GitHub Gist alternative. |
+| 📝 | [**opengist**](charts/opengist) | `1.15.1` | [Opengist](https://github.com/thomiceli/opengist) — self-hosted, Git-backed Pastebin / GitHub Gist alternative. |
 | 🌐 | [**technitium-dnsserver**](charts/technitium-dnsserver) | `15.4.0` | [Technitium DNS Server](https://github.com/TechnitiumSoftware/DnsServer) — recursive / authoritative DNS, PiHole & AdGuard alternative. |
 | 📤 | [**transfer.sh**](charts/transfer.sh) | `v1.6.1` | [transfer.sh](https://github.com/dutchcoders/transfer.sh) — CLI-friendly file-sharing with pluggable storage backends. |
 | 🪟 | [**winbox**](charts/winbox) | `3.40` | [MikroTik Winbox](https://github.com/obeone/winbox-docker) in your browser — VNC-streamed, Wine-powered. |

--- a/charts/cyberchef/Chart.yaml
+++ b/charts/cyberchef/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v11.2.0
+appVersion: v11.3.0
 description: GCHQ CyberChef [multi-arch]
 name: cyberchef
-version: 2.0.2
+version: 2.0.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - cyberchef
@@ -20,5 +20,7 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
+    - kind: changed
+      description: Bump appVersion to v11.3.0
     - kind: changed
       description: Regenerate README from the unified helm-docs template

--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.18
-appVersion: "2.11.170"
+version: 2.0.19
+appVersion: "2.11.174"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -57,3 +57,5 @@ annotations:
       description: "2026-08-01: Bump appVersion to 2.11.167"
     - kind: changed
       description: "2026-08-03: Bump appVersion to 2.11.170"
+    - kind: changed
+      description: "2026-08-04: Bump appVersion to 2.11.174"

--- a/charts/opengist/Chart.yaml
+++ b/charts/opengist/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opengist
-version: 1.1.5
-appVersion: 1.15.0
+version: 1.1.6
+appVersion: 1.15.1
 kubeVersion: ">=1.16.0-0"
 
 description: >-
@@ -41,6 +41,8 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
+    - kind: changed
+      description: Update Opengist to 1.15.1
     - kind: changed
       description: Update Opengist to 1.15.0
     - kind: added


### PR DESCRIPTION
Bumps to latest upstream releases:

- cyberchef: v11.2.0 -> v11.3.0
- firecrawl: 2.11.170 -> 2.11.174
- opengist: 1.15.0 -> 1.15.1

`helm lint` passes for all three charts. No dependency version changes.