### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.19
-appVersion: "2.11.174"
+version: 2.0.20
+appVersion: "2.11.182"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -59,3 +59,5 @@ annotations:
       description: "2026-08-03: Bump appVersion to 2.11.170"
     - kind: changed
       description: "2026-08-04: Bump appVersion to 2.11.174"
+    - kind: changed
+      description: "2026-08-05: Bump appVersion to 2.11.182"


### PR DESCRIPTION
## Updated charts

- firecrawl: 2.11.174 -> 2.11.182

No charts were skipped.