### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.20
-appVersion: "2.11.182"
+version: 2.0.21
+appVersion: "2.11.191"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -61,3 +61,5 @@ annotations:
       description: "2026-08-04: Bump appVersion to 2.11.174"
     - kind: changed
       description: "2026-08-05: Bump appVersion to 2.11.182"
+    - kind: changed
+      description: "2026-08-07: Bump appVersion to 2.11.191"


### PR DESCRIPTION
Updates the following chart to its latest upstream release:

- firecrawl: 2.11.182 -> 2.11.191