### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.21
-appVersion: "2.11.191"
+version: 2.0.22
+appVersion: "2.11.192"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -63,3 +63,5 @@ annotations:
       description: "2026-08-05: Bump appVersion to 2.11.182"
     - kind: changed
       description: "2026-08-07: Bump appVersion to 2.11.191"
+    - kind: changed
+      description: "2026-08-08: Bump appVersion to 2.11.192"


### PR DESCRIPTION
## Summary

- Bump firecrawl chart to 2.0.22 (appVersion 2.11.192)

No charts were skipped in this run.