### PR TITLE
chore: update charts to latest upstream versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ helm install my-release obeone/<chart> --verify
 
 | | Chart | App | Description |
 | :-: | --- | --- | --- |
-| 🕵️ | [**cloakbrowser-mcp**](charts/cloakbrowser-mcp) | `1.8.0` | [CloakBrowser MCP](https://github.com/swimmwatch/cloakbrowser-mcp) — Playwright browser-automation MCP server over HTTP, backed by a stealth Chromium. |
+| 🕵️ | [**cloakbrowser-mcp**](charts/cloakbrowser-mcp) | `1.11.0` | [CloakBrowser MCP](https://github.com/swimmwatch/cloakbrowser-mcp) — Playwright browser-automation MCP server over HTTP, backed by a stealth Chromium. |
 | 🔪 | [**cyberchef**](charts/cyberchef) | `v11.3.0` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
 | 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.16` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
 | 🖌️ | [**draw-things**](charts/draw-things) | `latest` | [Draw Things](https://drawthings.ai) gRPC server — Stable Diffusion inference backend for the macOS/iOS app, GPU-accelerated. |
-| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.193` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
+| 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.197` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
 | 🎨 | [**fooocus**](charts/fooocus) | `latest` | [Fooocus](https://github.com/lllyasviel/Fooocus) — open-source image-generation UI on top of Stable Diffusion. |
 | 🌍 | [**libretranslate**](charts/libretranslate) | `v1.9.6` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
 | 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |

--- a/charts/cloakbrowser-mcp/Chart.yaml
+++ b/charts/cloakbrowser-mcp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cloakbrowser-mcp
-version: 0.2.3
-appVersion: "1.10.0"
+version: 0.2.4
+appVersion: "1.11.0"
 kubeVersion: ">=1.31.0-0"
 
 description: >-
@@ -47,3 +47,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Add a disabled Gateway API HTTPRoute example mirroring the Ingress
+    - kind: changed
+      description: "2026-08-11: Bump appVersion to 1.11.0"

--- a/charts/firecrawl/Chart.yaml
+++ b/charts/firecrawl/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: firecrawl
-version: 2.0.23
-appVersion: "2.11.193"
+version: 2.0.24
+appVersion: "2.11.197"
 kubeVersion: ">=1.25.0-0"
 
 description: >-
@@ -67,3 +67,5 @@ annotations:
       description: "2026-08-08: Bump appVersion to 2.11.192"
     - kind: changed
       description: "2026-08-09: Bump appVersion to 2.11.193"
+    - kind: changed
+      description: "2026-08-11: Bump appVersion to 2.11.197"


### PR DESCRIPTION
## Summary

- cloakbrowser-mcp: 1.10.0 -> 1.11.0
- firecrawl: 2.11.193 -> 2.11.197

## Test plan

- [x] `helm lint charts/cloakbrowser-mcp`
- [x] `helm lint charts/firecrawl`