### PR TITLE
chore(winbox): deprecate chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ helm install my-release obeone/<chart> --verify
 | :-: | --- | --- | --- |
 | 🕵️ | [**cloakbrowser-mcp**](charts/cloakbrowser-mcp) | `1.11.0` | [CloakBrowser MCP](https://github.com/swimmwatch/cloakbrowser-mcp) — Playwright browser-automation MCP server over HTTP, backed by a stealth Chromium. |
 | 🔪 | [**cyberchef**](charts/cyberchef) | `v11.3.0` | GCHQ's [Cyber Swiss Army Knife](https://github.com/gchq/CyberChef) — encode, decode, encrypt, analyze. Multi-arch. |
-| 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.16` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
+| 🛡️ | [**dnscrypt-proxy**](charts/dnscrypt-proxy) | `2.1.18` | Flexible [DNS proxy](https://github.com/DNSCrypt/dnscrypt-proxy) with encrypted DNS protocols (DoH, DoT, DNSCrypt). |
 | 🖌️ | [**draw-things**](charts/draw-things) | `latest` | [Draw Things](https://drawthings.ai) gRPC server — Stable Diffusion inference backend for the macOS/iOS app, GPU-accelerated. |
 | 🔥 | [**firecrawl**](charts/firecrawl) | `2.11.198` | [Firecrawl](https://github.com/firecrawl/firecrawl) — crawl & scrape sites into LLM-ready data (markdown, HTML, JSON). Self-hosted API, workers & Playwright. |
 | 🎨 | [**fooocus**](charts/fooocus) | `latest` | [Fooocus](https://github.com/lllyasviel/Fooocus) — open-source image-generation UI on top of Stable Diffusion. |
 | 🌍 | [**libretranslate**](charts/libretranslate) | `v1.9.6` | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) — free, offline-capable machine-translation API. |
 | 📡 | [**mktxp**](charts/mktxp) | `latest` | [MKTXP](https://github.com/akpw/mktxp) — Prometheus exporter for MikroTik RouterOS metrics. |
-| 📂 | [**nfs-server**](charts/nfs-server) | `2.2.2` | Lightweight, multi-arch [containerized NFS server](https://github.com/obeone/docker-nfs-server). |
+| 📂 | [**nfs-server**](charts/nfs-server) | `2.2.3` | Lightweight, multi-arch [containerized NFS server](https://github.com/obeone/docker-nfs-server). |
 | 🦙 | [**ollama**](charts/ollama) | `latest` | [Ollama](https://ollama.com) — run LLMs locally, with an optional single-switch transparent Prometheus exporter/proxy sidecar (cosign-signed). GPU-accelerated, multi-arch. |
 | 💬 | [**olvid-bot**](charts/olvid-bot) | `2.0.1` | [Olvid bot-daemon](https://gitlab.com/olvid/olvid) — bridge to automate Olvid secure-messaging groups. |
 | 📝 | [**opengist**](charts/opengist) | `1.15.1` | [Opengist](https://github.com/thomiceli/opengist) — self-hosted, Git-backed Pastebin / GitHub Gist alternative. |
 | 🌐 | [**technitium-dnsserver**](charts/technitium-dnsserver) | `15.4.0` | [Technitium DNS Server](https://github.com/TechnitiumSoftware/DnsServer) — recursive / authoritative DNS, PiHole & AdGuard alternative. |
 | 📤 | [**transfer.sh**](charts/transfer.sh) | `v1.6.1` | [transfer.sh](https://github.com/dutchcoders/transfer.sh) — CLI-friendly file-sharing with pluggable storage backends. |
-| 🪟 | [**winbox**](charts/winbox) | `3.40` | [MikroTik Winbox](https://github.com/obeone/winbox-docker) in your browser — VNC-streamed, Wine-powered. |
+| 🪟 | [**winbox**](charts/winbox) | `3.40` | **Deprecated.** [MikroTik Winbox](https://github.com/obeone/winbox-docker) in your browser — VNC-streamed, Wine-powered. Upstream is archived (no image rebuild since 2023); use MikroTik's native WinBox 4 instead. |
 
 > 💡 Each chart ships with a per-folder `README.md` and a `values.yaml` annotated for [helm-docs](https://github.com/norwoodj/helm-docs).
 

--- a/charts/cloakbrowser-mcp/README.md
+++ b/charts/cloakbrowser-mcp/README.md
@@ -7,7 +7,7 @@
 -->
 # cloakbrowser-mcp
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cloakbrowser-mcp)
 
 CloakBrowser MCP — a Model Context Protocol browser-automation server that runs upstream @playwright/mcp with the CloakBrowser Chromium binary. This Helm chart packages the bridge in its streamable-http transport so it can be reached over the network, driven entirely from values.yaml via the bjw-s common library.

--- a/charts/cyberchef/README.md
+++ b/charts/cyberchef/README.md
@@ -7,7 +7,7 @@
 -->
 # cyberchef
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: v11.2.0](https://img.shields.io/badge/AppVersion-v11.2.0-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![AppVersion: v11.3.0](https://img.shields.io/badge/AppVersion-v11.3.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/cyberchef)
 
 GCHQ CyberChef [multi-arch]

--- a/charts/opengist/README.md
+++ b/charts/opengist/README.md
@@ -7,7 +7,7 @@
 -->
 # opengist
 
-![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![AppVersion: 1.15.0](https://img.shields.io/badge/AppVersion-1.15.0-informational?style=flat-square)
+![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![AppVersion: 1.15.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/opengist)
 
 Opengist is a self-hosted Pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface. It is similar to GitHub Gist, but open-source and self-hosted.

--- a/charts/winbox/Chart.yaml
+++ b/charts/winbox/Chart.yaml
@@ -3,12 +3,21 @@ appVersion: "3.40"
 description: |
   Mikrotik Winbox in browser
 
+  DEPRECATED: this chart is no longer maintained and will receive no further
+  releases. Its upstream project (obeone/winbox-docker) was archived in
+  September 2026: the last image build dates from August 2023 (Winbox 3.40,
+  Ubuntu 20.04, Wine and KasmVNC of that time) and has had no security
+  updates since. MikroTik now ships WinBox 4 natively for Linux and macOS
+  (https://mikrotik.com/download), which removes most of the reason this
+  chart existed. Run the image at your own risk, or better, not at all.
+
   Access to Mikrotik Winbox using your browser. This container start a VNC server and client,
   with winbox started by Wine.
 
   Currently only available for amd64 platforms.
 name: winbox
-version: 1.3.9
+version: 1.4.0
+deprecated: true
 kubeVersion: ">=1.16.0-0"
 keywords:
   - winbox
@@ -36,5 +45,8 @@ annotations:
     - name: obeone
       email: obeone@obeone.org
   artifacthub.io/changes: |
-    - kind: added
-      description: Value schema
+    - kind: deprecated
+      description: >-
+        Chart deprecated. Upstream obeone/winbox-docker is archived: the image
+        has not been rebuilt since August 2023 and gets no security updates.
+        MikroTik ships WinBox 4 natively for Linux and macOS.

--- a/charts/winbox/README.md
+++ b/charts/winbox/README.md
@@ -7,10 +7,20 @@
 -->
 # winbox
 
-![Version: 1.3.9](https://img.shields.io/badge/Version-1.3.9-informational?style=flat-square) ![AppVersion: 3.40](https://img.shields.io/badge/AppVersion-3.40-informational?style=flat-square)
+> **:exclamation: This Helm Chart is deprecated!**
+
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 3.40](https://img.shields.io/badge/AppVersion-3.40-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obeone)](https://artifacthub.io/packages/helm/obeone/winbox)
 
 Mikrotik Winbox in browser
+
+DEPRECATED: this chart is no longer maintained and will receive no further
+releases. Its upstream project (obeone/winbox-docker) was archived in
+September 2026: the last image build dates from August 2023 (Winbox 3.40,
+Ubuntu 20.04, Wine and KasmVNC of that time) and has had no security
+updates since. MikroTik now ships WinBox 4 natively for Linux and macOS
+(https://mikrotik.com/download), which removes most of the reason this
+chart existed. Run the image at your own risk, or better, not at all.
 
 Access to Mikrotik Winbox using your browser. This container start a VNC server and client,
 with winbox started by Wine.


### PR DESCRIPTION
The upstream project, obeone/winbox-docker, was archived today. The image has not been rebuilt since August 2023 (Winbox 3.40 on Ubuntu 20.04, with the Wine and KasmVNC of that era) and has had no security updates since. MikroTik now ships WinBox 4 natively for Linux and macOS, so there is no real reason to keep this chart alive.

What this does:

- `deprecated: true` in Chart.yaml, version 1.3.9 -> 1.4.0 so chart-releaser publishes the deprecation
- deprecation notice and rationale in the chart description (shows up on Artifact Hub and in the chart README)
- root README entry flagged as deprecated
- Artifact Hub changelog entry of kind `deprecated`

Second commit resyncs the version badges in four other chart READMEs that the automated bumps had left behind. helm-docs output only, no content change.

`helm dep up` and `helm lint` pass on the chart.